### PR TITLE
feat: Direct writer

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
@@ -10,25 +10,21 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto.ProtoRows;
 import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto.ProtoSchema;
 import com.google.cloud.bigquery.storage.v1alpha2.Storage.AppendRowsRequest;
-import com.google.cloud.bigquery.storage.v1alpha2.Storage.CreateWriteStreamRequest;
-import com.google.cloud.bigquery.storage.v1alpha2.Stream.WriteStream;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
-
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 
 /**
- * Writer that can help user to write data to BigQuery. This is a simplified version of the Write API.
- * For users writing with COMMITTED stream and don't care about row deduplication, it is recommended to use this Writer.
+ * Writer that can help user to write data to BigQuery. This is a simplified version of the Write
+ * API. For users writing with COMMITTED stream and don't care about row deduplication, it is
+ * recommended to use this Writer.
  *
- * It supports message batching and flow control. It handles stream creation and schema update.
+ * <p>It supports message batching and flow control. It handles stream creation and schema update.
  *
  * <pre>{@code
  * DataProto data1;
@@ -52,13 +48,32 @@ public class DirectWriter implements AutoCloseable {
 
   /**
    * Constructor of DirectWriter.
-   * @param tableName Name of the table for ingest in format of 'projects/{pid}/datasets/{did}/tables/{tid}'.
-   * @param messageDescriptor The descriptor of the input message, to be used to interpret the input messages.
+   *
+   * @param tableName Name of the table for ingest in format of
+   *     'projects/{pid}/datasets/{did}/tables/{tid}'.
+   * @param messageDescriptor The descriptor of the input message, to be used to interpret the input
+   *     messages.
    */
   public DirectWriter(Builder builder) throws Exception {
     userSchema = ProtoSchemaConverter.convert(builder.userSchema);
     writerCache = WriterCache.getInstance();
-    writer = writerCache.getWriter(builder.tableName);
+    StreamWriter writer1 = writerCache.getWriter(builder.tableName);
+    // If user specifies a different setting, then create a new writer according to the setting.
+    if ((builder.batchingSettings != null
+            && builder.batchingSettings != writer1.getBatchingSettings())
+        || (builder.retrySettings != null && builder.retrySettings != writer1.getRetrySettings())) {
+      StreamWriter.Builder writerBuilder = StreamWriter.newBuilder(writer1.getStreamNameString());
+      if (builder.batchingSettings != null
+          && builder.batchingSettings != writer1.getBatchingSettings()) {
+        writerBuilder.setBatchingSettings(builder.batchingSettings);
+      }
+      if (builder.retrySettings != null && builder.retrySettings != writer1.getRetrySettings()) {
+        writerBuilder.setRetrySettings(builder.retrySettings);
+      }
+      writer1.close();
+      writer1 = writerBuilder.build();
+    }
+    writer = writer1;
   }
 
   @Override
@@ -67,11 +82,13 @@ public class DirectWriter implements AutoCloseable {
   }
 
   /**
-   * The row is represented in proto buffer messages and it must be compatible to the table's schema in BigQuery.
+   * The row is represented in proto buffer messages and it must be compatible to the table's schema
+   * in BigQuery.
    *
-   * @param protoRows rows in proto buffer format. They must be compatible with the schema set on the writer.
-   * @return A future that contains the offset at which the append happened. Only when the future returns with valid
-   *         offset, then the append actually happened.
+   * @param protoRows rows in proto buffer format. They must be compatible with the schema set on
+   *     the writer.
+   * @return A future that contains the offset at which the append happened. Only when the future
+   *     returns with valid offset, then the append actually happened.
    * @throws Exception
    */
   public ApiFuture<Long> append(List<MessageLite> protoRows) throws Exception {
@@ -87,7 +104,7 @@ public class DirectWriter implements AutoCloseable {
 
     return ApiFutures.<Storage.AppendRowsResponse, Long>transform(
         writer.append(AppendRowsRequest.newBuilder().setProtoRows(data.build()).build()),
-        new ApiFunction<Storage.AppendRowsResponse, Long>(){
+        new ApiFunction<Storage.AppendRowsResponse, Long>() {
           @Override
           public Long apply(Storage.AppendRowsResponse appendRowsResponse) {
             return Long.valueOf(appendRowsResponse.getOffset());
@@ -97,64 +114,61 @@ public class DirectWriter implements AutoCloseable {
   }
 
   /**
-   * After this call, messages will be appended using the new schema. Note that user is responsible to keep
-   * the schema here in sync with the table's actual schema. If they ran out of date, the append may fail.
-   * User can keep trying, until the table's new schema is picked up.
+   * After this call, messages will be appended using the new schema. Note that user is responsible
+   * to keep the schema here in sync with the table's actual schema. If they ran out of date, the
+   * append may fail. User can keep trying, until the table's new schema is picked up.
+   *
    * @param newSchema
    * @throws IOException
    * @throws InterruptedException
    */
-  public void updateSchema(Descriptors.Descriptor newSchema) throws IOException, InterruptedException {
+  public void updateSchema(Descriptors.Descriptor newSchema)
+      throws IOException, InterruptedException {
     Preconditions.checkArgument(newSchema != null);
     writer.refreshAppend();
     userSchema = ProtoSchemaConverter.convert(newSchema);
   }
 
-  public static DirectWriter.Builder newBuilder(String tableName, Descriptors.Descriptor userSchema) {
+  /** Returns the batch settings on the writer. */
+  public BatchingSettings getBatchSettings() {
+    return writer.getBatchingSettings();
+  }
+
+  /** Returns the retry settings on the writer. */
+  public RetrySettings getRetrySettings() {
+    return writer.getRetrySettings();
+  }
+
+  @VisibleForTesting
+  public int getCachedTableCount() {
+    return writerCache.cachedTableCount();
+  }
+
+  @VisibleForTesting
+  public int getCachedStreamCount(String tableName) {
+    return writerCache.cachedStreamCount(tableName);
+  }
+
+  public static DirectWriter.Builder newBuilder(
+      String tableName, Descriptors.Descriptor userSchema) {
     return new DirectWriter.Builder(tableName, userSchema);
   }
 
-  /** A builder of {@link DirectWriter}s. */
+  /** A builder of {@link DirectWriter}s.
+   *  As of now, user can specify only the batch and retry settings, but not other common connection settings.
+   **/
   public static final class Builder {
     private final String tableName;
     private final Descriptors.Descriptor userSchema;
 
-    // Connection settings
-    private static final int THREADS_PER_CPU = 5;
-    ExecutorProvider executorProvider =
-        InstantiatingExecutorProvider.newBuilder()
-        .setExecutorThreadCount(THREADS_PER_CPU * Runtime.getRuntime().availableProcessors())
-        .build();
-    private CredentialsProvider credentialsProvider =
-        BigQueryWriteSettings.defaultCredentialsProviderBuilder().build();
-    TransportChannelProvider channelProvider =
-        BigQueryWriteSettings.defaultGrpcTransportProviderBuilder().setChannelsPerCpu(1).build();
-
-    // {@code StreamWriter} settings, if null, default to the settings on {@code StreamWriter}.
+    // If null, default to the settings on the writer in the cache, which in term defaults to existing settings on
+    // {@code StreamWriter}.
     RetrySettings retrySettings = null;
     BatchingSettings batchingSettings = null;
 
     private Builder(String tableName, Descriptors.Descriptor userSchema) {
       this.tableName = Preconditions.checkNotNull(tableName);
       this.userSchema = Preconditions.checkNotNull(userSchema);
-    }
-
-    /**
-     * {@code ChannelProvider} to use to create Channels, which must point at Cloud BigQuery Storage
-     * API endpoint.
-     *
-     * <p>For performance, this client benefits from having multiple underlying connections. See
-     * {@link com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.Builder#setPoolSize(int)}.
-     */
-    public Builder setChannelProvider(TransportChannelProvider channelProvider) {
-      this.channelProvider = Preconditions.checkNotNull(channelProvider);
-      return this;
-    }
-
-    /** {@code CredentialsProvider} to use to create Credentials to authenticate calls. */
-    public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
-      this.credentialsProvider = Preconditions.checkNotNull(credentialsProvider);
-      return this;
     }
 
     /** Sets the {@code BatchSettings} on the writer. */
@@ -166,12 +180,6 @@ public class DirectWriter implements AutoCloseable {
     /** Sets the {@code RetrySettings} on the writer. */
     public Builder setRetrySettings(RetrySettings retrySettings) {
       this.retrySettings = Preconditions.checkNotNull(retrySettings);
-      return this;
-    }
-
-    /** Gives the ability to set a custom executor to be used by the library. */
-    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
-      this.executorProvider = Preconditions.checkNotNull(executorProvider);
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
@@ -98,7 +98,8 @@ public class DirectWriter {
   }
 
   @VisibleForTesting
-  public static void testSetStub(BigQueryWriteClient stub, int maxTableEntry) {
-    cache = WriterCache.getTestInstance(stub, maxTableEntry);
+  public static void testSetStub(
+      BigQueryWriteClient stub, int maxTableEntry, SchemaCompact schemaCheck) {
+    cache = WriterCache.getTestInstance(stub, maxTableEntry, schemaCheck);
   }
 }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
@@ -1,0 +1,183 @@
+package com.google.cloud.bigquery.storage.v1alpha2;
+
+import com.google.api.core.*;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto.ProtoRows;
+import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto.ProtoSchema;
+import com.google.cloud.bigquery.storage.v1alpha2.Storage.AppendRowsRequest;
+import com.google.cloud.bigquery.storage.v1alpha2.Storage.CreateWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1alpha2.Stream.WriteStream;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+
+/**
+ * Writer that can help user to write data to BigQuery. This is a simplified version of the Write API.
+ * For users writing with COMMITTED stream and don't care about row deduplication, it is recommended to use this Writer.
+ *
+ * It supports message batching and flow control. It handles stream creation and schema update.
+ *
+ * <pre>{@code
+ * DataProto data1;
+ * DirectWriter dw =
+ *   DirectWriter.newBuilder("projects/pid/datasets/did/tables/tid", DataProto.GetDescriptor()).build();
+ * ApiFuture<Long> response = dw.append({data1});
+ * DataProto2 data2; // new data with updated schema
+ * dw.updateSchema(DataProto2.GetDescriptor());
+ * ApiFuture<Long> response = dw.append({data2});
+ * }</pre>
+ *
+ * <p>{@link DirectWriter} will use the credentials set on the channel, which uses application
+ * default credentials through {@link GoogleCredentials#getApplicationDefault} by default.
+ */
+public class DirectWriter implements AutoCloseable {
+  private static final Logger LOG = Logger.getLogger(DirectWriter.class.getName());
+
+  private ProtoSchema userSchema;
+  private final StreamWriter writer;
+  private final WriterCache writerCache;
+
+  /**
+   * Constructor of DirectWriter.
+   * @param tableName Name of the table for ingest in format of 'projects/{pid}/datasets/{did}/tables/{tid}'.
+   * @param messageDescriptor The descriptor of the input message, to be used to interpret the input messages.
+   */
+  public DirectWriter(Builder builder) throws Exception {
+    userSchema = ProtoSchemaConverter.convert(builder.userSchema);
+    writerCache = WriterCache.getInstance();
+    writer = writerCache.getWriter(builder.tableName);
+  }
+
+  @Override
+  public void close() {
+    writerCache.returnWriter(writer);
+  }
+
+  /**
+   * The row is represented in proto buffer messages and it must be compatible to the table's schema in BigQuery.
+   *
+   * @param protoRows rows in proto buffer format. They must be compatible with the schema set on the writer.
+   * @return A future that contains the offset at which the append happened. Only when the future returns with valid
+   *         offset, then the append actually happened.
+   * @throws Exception
+   */
+  public ApiFuture<Long> append(List<MessageLite> protoRows) throws Exception {
+    ProtoRows.Builder rowsBuilder = ProtoRows.newBuilder();
+    Descriptors.Descriptor descriptor = null;
+    for (MessageLite protoRow : protoRows) {
+      rowsBuilder.addSerializedRows(protoRow.toByteString());
+    }
+
+    AppendRowsRequest.ProtoData.Builder data = AppendRowsRequest.ProtoData.newBuilder();
+    data.setWriterSchema(userSchema);
+    data.setRows(rowsBuilder.build());
+
+    return ApiFutures.<Storage.AppendRowsResponse, Long>transform(
+        writer.append(AppendRowsRequest.newBuilder().setProtoRows(data.build()).build()),
+        new ApiFunction<Storage.AppendRowsResponse, Long>(){
+          @Override
+          public Long apply(Storage.AppendRowsResponse appendRowsResponse) {
+            return Long.valueOf(appendRowsResponse.getOffset());
+          }
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  /**
+   * After this call, messages will be appended using the new schema. Note that user is responsible to keep
+   * the schema here in sync with the table's actual schema. If they ran out of date, the append may fail.
+   * User can keep trying, until the table's new schema is picked up.
+   * @param newSchema
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public void updateSchema(Descriptors.Descriptor newSchema) throws IOException, InterruptedException {
+    Preconditions.checkArgument(newSchema != null);
+    writer.refreshAppend();
+    userSchema = ProtoSchemaConverter.convert(newSchema);
+  }
+
+  public static DirectWriter.Builder newBuilder(String tableName, Descriptors.Descriptor userSchema) {
+    return new DirectWriter.Builder(tableName, userSchema);
+  }
+
+  /** A builder of {@link DirectWriter}s. */
+  public static final class Builder {
+    private final String tableName;
+    private final Descriptors.Descriptor userSchema;
+
+    // Connection settings
+    private static final int THREADS_PER_CPU = 5;
+    ExecutorProvider executorProvider =
+        InstantiatingExecutorProvider.newBuilder()
+        .setExecutorThreadCount(THREADS_PER_CPU * Runtime.getRuntime().availableProcessors())
+        .build();
+    private CredentialsProvider credentialsProvider =
+        BigQueryWriteSettings.defaultCredentialsProviderBuilder().build();
+    TransportChannelProvider channelProvider =
+        BigQueryWriteSettings.defaultGrpcTransportProviderBuilder().setChannelsPerCpu(1).build();
+
+    // {@code StreamWriter} settings, if null, default to the settings on {@code StreamWriter}.
+    RetrySettings retrySettings = null;
+    BatchingSettings batchingSettings = null;
+
+    private Builder(String tableName, Descriptors.Descriptor userSchema) {
+      this.tableName = Preconditions.checkNotNull(tableName);
+      this.userSchema = Preconditions.checkNotNull(userSchema);
+    }
+
+    /**
+     * {@code ChannelProvider} to use to create Channels, which must point at Cloud BigQuery Storage
+     * API endpoint.
+     *
+     * <p>For performance, this client benefits from having multiple underlying connections. See
+     * {@link com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.Builder#setPoolSize(int)}.
+     */
+    public Builder setChannelProvider(TransportChannelProvider channelProvider) {
+      this.channelProvider = Preconditions.checkNotNull(channelProvider);
+      return this;
+    }
+
+    /** {@code CredentialsProvider} to use to create Credentials to authenticate calls. */
+    public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
+      this.credentialsProvider = Preconditions.checkNotNull(credentialsProvider);
+      return this;
+    }
+
+    /** Sets the {@code BatchSettings} on the writer. */
+    public Builder setBatchingSettings(BatchingSettings batchingSettings) {
+      this.batchingSettings = Preconditions.checkNotNull(batchingSettings);
+      return this;
+    }
+
+    /** Sets the {@code RetrySettings} on the writer. */
+    public Builder setRetrySettings(RetrySettings retrySettings) {
+      this.retrySettings = Preconditions.checkNotNull(retrySettings);
+      return this;
+    }
+
+    /** Gives the ability to set a custom executor to be used by the library. */
+    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
+      this.executorProvider = Preconditions.checkNotNull(executorProvider);
+      return this;
+    }
+
+    /** Builds the {@code DirectWriter}. */
+    public DirectWriter build() throws Exception {
+      return new DirectWriter(this);
+    }
+  }
+}

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
@@ -1,22 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigquery.storage.v1alpha2;
 
 import com.google.api.core.*;
-import com.google.api.gax.batching.BatchingSettings;
-import com.google.api.gax.core.CredentialsProvider;
-import com.google.api.gax.core.ExecutorProvider;
-import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.retrying.RetrySettings;
-import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto.ProtoRows;
-import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto.ProtoSchema;
 import com.google.cloud.bigquery.storage.v1alpha2.Storage.AppendRowsRequest;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.MessageLite;
+import com.google.protobuf.Message;
+import io.grpc.Status;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 
 /**
@@ -24,82 +36,54 @@ import java.util.logging.Logger;
  * API. For users writing with COMMITTED stream and don't care about row deduplication, it is
  * recommended to use this Writer.
  *
- * <p>It supports message batching and flow control. It handles stream creation and schema update.
- *
  * <pre>{@code
- * DataProto data1;
- * DirectWriter dw =
- *   DirectWriter.newBuilder("projects/pid/datasets/did/tables/tid", DataProto.GetDescriptor()).build();
- * ApiFuture<Long> response = dw.append({data1});
- * DataProto2 data2; // new data with updated schema
- * dw.updateSchema(DataProto2.GetDescriptor());
- * ApiFuture<Long> response = dw.append({data2});
+ * DataProto data;
+ * ApiFuture<Long> response = DirectWriter.<DataProto>append("projects/pid/datasets/did/tables/tid", Arrays.asList(data1));
  * }</pre>
  *
  * <p>{@link DirectWriter} will use the credentials set on the channel, which uses application
  * default credentials through {@link GoogleCredentials#getApplicationDefault} by default.
  */
-public class DirectWriter implements AutoCloseable {
+public class DirectWriter {
   private static final Logger LOG = Logger.getLogger(DirectWriter.class.getName());
-
-  private ProtoSchema userSchema;
-  private final StreamWriter writer;
-  private final WriterCache writerCache;
+  private static WriterCache cache = null;
+  private static Lock cacheLock = new ReentrantLock();
 
   /**
-   * Constructor of DirectWriter.
+   * Append rows to the given table.
    *
-   * @param tableName Name of the table for ingest in format of
-   *     'projects/{pid}/datasets/{did}/tables/{tid}'.
-   * @param messageDescriptor The descriptor of the input message, to be used to interpret the input
-   *     messages.
-   */
-  public DirectWriter(Builder builder) throws Exception {
-    userSchema = ProtoSchemaConverter.convert(builder.userSchema);
-    writerCache = WriterCache.getInstance();
-    StreamWriter writer1 = writerCache.getWriter(builder.tableName);
-    // If user specifies a different setting, then create a new writer according to the setting.
-    if ((builder.batchingSettings != null
-            && builder.batchingSettings != writer1.getBatchingSettings())
-        || (builder.retrySettings != null && builder.retrySettings != writer1.getRetrySettings())) {
-      StreamWriter.Builder writerBuilder = StreamWriter.newBuilder(writer1.getStreamNameString());
-      if (builder.batchingSettings != null
-          && builder.batchingSettings != writer1.getBatchingSettings()) {
-        writerBuilder.setBatchingSettings(builder.batchingSettings);
-      }
-      if (builder.retrySettings != null && builder.retrySettings != writer1.getRetrySettings()) {
-        writerBuilder.setRetrySettings(builder.retrySettings);
-      }
-      writer1.close();
-      writer1 = writerBuilder.build();
-    }
-    writer = writer1;
-  }
-
-  @Override
-  public void close() {
-    writerCache.returnWriter(writer);
-  }
-
-  /**
-   * The row is represented in proto buffer messages and it must be compatible to the table's schema
-   * in BigQuery.
-   *
-   * @param protoRows rows in proto buffer format. They must be compatible with the schema set on
-   *     the writer.
+   * @param tableName table name in the form of "projects/{pName}/datasets/{dName}/tables/{tName}"
+   * @param protoRows rows in proto buffer format.
    * @return A future that contains the offset at which the append happened. Only when the future
    *     returns with valid offset, then the append actually happened.
-   * @throws Exception
+   * @throws IOException, InterruptedException, InvalidArgumentException
    */
-  public ApiFuture<Long> append(List<MessageLite> protoRows) throws Exception {
+  public static <T extends Message> ApiFuture<Long> append(String tableName, List<T> protoRows)
+      throws IOException, InterruptedException, InvalidArgumentException {
+    if (protoRows.isEmpty()) {
+      throw new InvalidArgumentException(
+          new Exception("Empty rows are not allowed"),
+          GrpcStatusCode.of(Status.Code.INVALID_ARGUMENT),
+          false);
+    }
+    try {
+      cacheLock.lock();
+      if (cache == null) {
+        cache = WriterCache.getInstance();
+      }
+    } finally {
+      cacheLock.unlock();
+    }
+
+    StreamWriter writer = cache.getTableWriter(tableName, protoRows.get(0).getDescriptorForType());
     ProtoRows.Builder rowsBuilder = ProtoRows.newBuilder();
     Descriptors.Descriptor descriptor = null;
-    for (MessageLite protoRow : protoRows) {
+    for (Message protoRow : protoRows) {
       rowsBuilder.addSerializedRows(protoRow.toByteString());
     }
 
     AppendRowsRequest.ProtoData.Builder data = AppendRowsRequest.ProtoData.newBuilder();
-    data.setWriterSchema(userSchema);
+    data.setWriterSchema(ProtoSchemaConverter.convert(protoRows.get(0).getDescriptorForType()));
     data.setRows(rowsBuilder.build());
 
     return ApiFutures.<Storage.AppendRowsResponse, Long>transform(
@@ -113,79 +97,8 @@ public class DirectWriter implements AutoCloseable {
         MoreExecutors.directExecutor());
   }
 
-  /**
-   * After this call, messages will be appended using the new schema. Note that user is responsible
-   * to keep the schema here in sync with the table's actual schema. If they ran out of date, the
-   * append may fail. User can keep trying, until the table's new schema is picked up.
-   *
-   * @param newSchema
-   * @throws IOException
-   * @throws InterruptedException
-   */
-  public void updateSchema(Descriptors.Descriptor newSchema)
-      throws IOException, InterruptedException {
-    Preconditions.checkArgument(newSchema != null);
-    writer.refreshAppend();
-    userSchema = ProtoSchemaConverter.convert(newSchema);
-  }
-
-  /** Returns the batch settings on the writer. */
-  public BatchingSettings getBatchSettings() {
-    return writer.getBatchingSettings();
-  }
-
-  /** Returns the retry settings on the writer. */
-  public RetrySettings getRetrySettings() {
-    return writer.getRetrySettings();
-  }
-
   @VisibleForTesting
-  public int getCachedTableCount() {
-    return writerCache.cachedTableCount();
-  }
-
-  @VisibleForTesting
-  public int getCachedStreamCount(String tableName) {
-    return writerCache.cachedStreamCount(tableName);
-  }
-
-  public static DirectWriter.Builder newBuilder(
-      String tableName, Descriptors.Descriptor userSchema) {
-    return new DirectWriter.Builder(tableName, userSchema);
-  }
-
-  /** A builder of {@link DirectWriter}s.
-   *  As of now, user can specify only the batch and retry settings, but not other common connection settings.
-   **/
-  public static final class Builder {
-    private final String tableName;
-    private final Descriptors.Descriptor userSchema;
-
-    // If null, default to the settings on the writer in the cache, which in term defaults to existing settings on
-    // {@code StreamWriter}.
-    RetrySettings retrySettings = null;
-    BatchingSettings batchingSettings = null;
-
-    private Builder(String tableName, Descriptors.Descriptor userSchema) {
-      this.tableName = Preconditions.checkNotNull(tableName);
-      this.userSchema = Preconditions.checkNotNull(userSchema);
-    }
-
-    /** Sets the {@code BatchSettings} on the writer. */
-    public Builder setBatchingSettings(BatchingSettings batchingSettings) {
-      this.batchingSettings = Preconditions.checkNotNull(batchingSettings);
-      return this;
-    }
-
-    /** Sets the {@code RetrySettings} on the writer. */
-    public Builder setRetrySettings(RetrySettings retrySettings) {
-      this.retrySettings = Preconditions.checkNotNull(retrySettings);
-      return this;
-    }
-
-    /** Builds the {@code DirectWriter}. */
-    public DirectWriter build() throws Exception {
-      return new DirectWriter(this);
-    }
+  public static void testSetStub(BigQueryWriteClient stub, int maxTableEntry) {
+    cache = WriterCache.getTestInstance(stub, maxTableEntry);
   }
 }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompact.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompact.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.storage.v1alpha2;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Descriptors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A class that checks the schema compatibility between user schema in proto descriptor and Bigquery
+ * table schema. If this check is passed, then user can write to BigQuery table using the user
+ * schema, otherwise the write will fail.
+ *
+ * <p>The implementation as of now is not complete, which measn, if this check passed, there is
+ * still a possbility of writing will fail.
+ */
+public class SchemaCompact {
+  private BigQuery bigquery;
+  private static SchemaCompact compact;
+  private static String tablePatternString = "projects/([^/]+)/datasets/([^/]+)/tables/([^/]+)";
+  private static Pattern tablePattern = Pattern.compile(tablePatternString);
+
+  private SchemaCompact(BigQuery bigquery) {
+    this.bigquery = bigquery;
+  }
+
+  /**
+   * Gets a singleton {code SchemaCompact} object.
+   *
+   * @return
+   */
+  public static SchemaCompact getInstance() {
+    if (compact == null) {
+      RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
+      compact = new SchemaCompact(bigqueryHelper.getOptions().getService());
+    }
+    return compact;
+  }
+
+  /**
+   * Gets a {code SchemaCompact} object with custom BigQuery stub.
+   *
+   * @param bigquery
+   * @return
+   */
+  @VisibleForTesting
+  public static SchemaCompact getInstance(BigQuery bigquery) {
+    return new SchemaCompact(bigquery);
+  }
+
+  private TableId getTableId(String tableName) {
+    Matcher matcher = tablePattern.matcher(tableName);
+    if (!matcher.matches() || matcher.groupCount() != 3) {
+      throw new IllegalArgumentException("Invalid table name: " + tableName);
+    }
+    return TableId.of(matcher.group(1), matcher.group(2), matcher.group(3));
+  }
+
+  /**
+   * Checks if the userSchema is compatible with the table's current schema for writing. The current
+   * implementatoin is not complete. If the check failed, the write couldn't succeed.
+   *
+   * @param tableName The name of the table to write to.
+   * @param userSchema The schema user uses to append data.
+   * @throws IllegalArgumentException the check failed.
+   */
+  public void check(String tableName, Descriptors.Descriptor userSchema)
+      throws IllegalArgumentException {
+    Table table = bigquery.getTable(getTableId(tableName));
+    Schema schema = table.getDefinition().getSchema();
+    // TODO: We only have very limited check here. More checks to be added.
+    if (schema.getFields().size() != userSchema.getFields().size()) {
+      throw new IllegalArgumentException(
+          "User schema doesn't have expected field number with BigQuery table schema, expected: "
+              + schema.getFields().size()
+              + " actual: "
+              + userSchema.getFields().size());
+    }
+  }
+}

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
@@ -275,7 +275,7 @@ public class StreamWriter implements AutoCloseable {
                 new Runnable() {
                   @Override
                   public void run() {
-                    LOG.info("Sending messages based on schedule");
+                    LOG.fine("Sending messages based on schedule");
                     activeAlarm.getAndSet(false);
                     messagesBatchLock.lock();
                     try {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
@@ -48,8 +48,15 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.threeten.bp.Duration;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * A BigQuery Stream Writer that can be used to write data into BigQuery Table.
+ *
+ * This is to be used to managed streaming write when you are working with PENDING streams or want to explicitly
+ * manage offset. In that most common cases when writing with COMMITTED stream without offset, please use a simpler
+ * writer {@code DirectWriter}.
  *
  * <p>A {@link StreamWrier} provides built-in capabilities to: handle batching of messages;
  * controlling memory utilization (through flow control); automatic connection re-establishment and
@@ -68,7 +75,12 @@ import org.threeten.bp.Duration;
 public class StreamWriter implements AutoCloseable {
   private static final Logger LOG = Logger.getLogger(StreamWriter.class.getName());
 
+  private static String streamPatternString = "(projects/[^/]+/datasets/[^/]+/tables/[^/]+)/streams/.*";
+
+  private static Pattern streamPattern = Pattern.compile(streamPatternString);
+
   private final String streamName;
+  private final String tableName;
 
   private final BatchingSettings batchingSettings;
   private final RetrySettings retrySettings;
@@ -104,12 +116,17 @@ public class StreamWriter implements AutoCloseable {
     return 5000L;
   }
 
-  private StreamWriter(Builder builder) throws IOException {
+  private StreamWriter(Builder builder) throws Exception {
+    Matcher matcher = streamPattern.matcher(builder.streamName);
+    if (!matcher.matches()) {
+      throw new InvalidArgumentException(null, GrpcStatusCode.of(Status.Code.INVALID_ARGUMENT), false);
+    }
     streamName = builder.streamName;
+    tableName = matcher.group(1);
 
     this.batchingSettings = builder.batchingSettings;
     this.retrySettings = builder.retrySettings;
-    this.messagesBatch = new MessagesBatch(batchingSettings);
+    this.messagesBatch = new MessagesBatch(batchingSettings, this.streamName);
     messagesBatchLock = new ReentrantLock();
     activeAlarm = new AtomicBoolean(false);
     executor = builder.executorProvider.getExecutor();
@@ -134,6 +151,11 @@ public class StreamWriter implements AutoCloseable {
   /** Stream name we are writing to. */
   public String getStreamNameString() {
     return streamName;
+  }
+
+  /** Table name we are writing to. */
+  public String getTableNameString() {
+    return tableName;
   }
 
   /**
@@ -176,7 +198,7 @@ public class StreamWriter implements AutoCloseable {
       setupAlarm();
       if (!batchesToSend.isEmpty()) {
         for (final InflightBatch batch : batchesToSend) {
-          LOG.fine("Scheduling a batch for immediate sending.");
+          LOG.info("Scheduling a batch for immediate sending.");
           writeBatch(batch);
         }
       }
@@ -192,11 +214,13 @@ public class StreamWriter implements AutoCloseable {
    *
    * @throws IOException
    */
-  private void refreshAppend() throws IOException {
+  public void refreshAppend() throws IOException, InterruptedException {
     synchronized (this) {
       Preconditions.checkState(!shutdown.get(), "Cannot append on a shut-down writer.");
       if (stub != null) {
+        clientStream.closeSend();
         stub.shutdown();
+        stub.awaitTermination(1, TimeUnit.MINUTES);
       }
       backgroundResourceList.remove(stub);
       stub = BigQueryWriteClient.create(stubSettings);
@@ -212,19 +236,20 @@ public class StreamWriter implements AutoCloseable {
       }
     } catch (InterruptedException expected) {
     }
+    LOG.info("Write Stream " + streamName + " connection established");
   }
 
   private void setupAlarm() {
     if (!messagesBatch.isEmpty()) {
       if (!activeAlarm.getAndSet(true)) {
         long delayThresholdMs = getBatchingSettings().getDelayThreshold().toMillis();
-        LOG.log(Level.INFO, "Setting up alarm for the next {0} ms.", delayThresholdMs);
+        LOG.log(Level.FINE, "Setting up alarm for the next {0} ms.", delayThresholdMs);
         currentAlarmFuture =
             executor.schedule(
                 new Runnable() {
                   @Override
                   public void run() {
-                    LOG.fine("Sending messages based on schedule");
+                    LOG.info("Sending messages based on schedule");
                     activeAlarm.getAndSet(false);
                     messagesBatchLock.lock();
                     try {
@@ -264,6 +289,7 @@ public class StreamWriter implements AutoCloseable {
   }
 
   private void writeBatch(final InflightBatch inflightBatch) {
+    LOG.info("inflightBatch " + (inflightBatch != null));
     if (inflightBatch != null) {
       AppendRowsRequest request = inflightBatch.getMergedRequest();
       messagesWaiter.waitOnElementCount();
@@ -300,10 +326,12 @@ public class StreamWriter implements AutoCloseable {
     int batchSizeBytes;
     long expectedOffset;
     Boolean attachSchema;
+    String streamName;
 
     InflightBatch(
         List<AppendRequestAndFutureResponse> inflightRequests,
         int batchSizeBytes,
+        String streamName,
         Boolean attachSchema) {
       this.inflightRequests = inflightRequests;
       this.offsetList = new ArrayList<Long>(inflightRequests.size());
@@ -319,6 +347,7 @@ public class StreamWriter implements AutoCloseable {
       creationTime = System.currentTimeMillis();
       this.batchSizeBytes = batchSizeBytes;
       this.attachSchema = attachSchema;
+      this.streamName = streamName;
     }
 
     int count() {
@@ -345,15 +374,18 @@ public class StreamWriter implements AutoCloseable {
       }
       AppendRowsRequest.ProtoData.Builder data =
           inflightRequests.get(0).message.getProtoRows().toBuilder().setRows(rowsBuilder.build());
+      AppendRowsRequest.Builder requestBuilder = inflightRequests.get(0).message.toBuilder();
       if (!attachSchema) {
         data.clearWriterSchema();
+        requestBuilder.clearWriteStream();
       } else {
         if (!data.hasWriterSchema()) {
           throw new IllegalStateException(
               "The first message on the connection must have writer schema set");
         }
+        requestBuilder.setWriteStream(streamName);
       }
-      return inflightRequests.get(0).message.toBuilder().setProtoRows(data.build()).build();
+      return requestBuilder.setProtoRows(data.build()).build();
     }
 
     private void onFailure(Throwable t) {
@@ -453,13 +485,8 @@ public class StreamWriter implements AutoCloseable {
    *     WriteStream response = bigQueryWriteClient.createWriteStream(request);
    *     stream = response.getName();
    * }
-   * WriteStream writer = WriteStream.newBuilder(stream).build();
-   * try {
-   *   // ...
-   * } finally {
-   *   // When finished with the writer, make sure to shutdown to free up resources.
-   *   writer.shutdown();
-   *   writer.awaitTermination(1, TimeUnit.MINUTES);
+   * try (WriteStream writer = WriteStream.newBuilder(stream).build()) {
+   *   //...
    * }
    * }</pre>
    */
@@ -467,7 +494,7 @@ public class StreamWriter implements AutoCloseable {
     return new Builder(streamName);
   }
 
-  /** A builder of {@link Publisher}s. */
+  /** A builder of {@link StreamWriter}s. */
   public static final class Builder {
     static final Duration MIN_TOTAL_TIMEOUT = Duration.ofSeconds(10);
     static final Duration MIN_RPC_TIMEOUT = Duration.ofMillis(10);
@@ -475,7 +502,7 @@ public class StreamWriter implements AutoCloseable {
     // Meaningful defaults.
     static final long DEFAULT_ELEMENT_COUNT_THRESHOLD = 100L;
     static final long DEFAULT_REQUEST_BYTES_THRESHOLD = 100 * 1024L; // 100 kB
-    static final Duration DEFAULT_DELAY_THRESHOLD = Duration.ofMillis(1);
+    static final Duration DEFAULT_DELAY_THRESHOLD = Duration.ofMillis(10);
     static final FlowControlSettings DEFAULT_FLOW_CONTROL_SETTINGS =
         FlowControlSettings.newBuilder()
             .setLimitExceededBehavior(FlowController.LimitExceededBehavior.Block)
@@ -515,9 +542,6 @@ public class StreamWriter implements AutoCloseable {
     private TransportChannelProvider channelProvider =
         BigQueryWriteSettings.defaultGrpcTransportProviderBuilder().setChannelsPerCpu(1).build();
 
-    private HeaderProvider headerProvider = new NoHeaderProvider();
-    private HeaderProvider internalHeaderProvider =
-        BigQueryWriteSettings.defaultApiClientHeaderProviderBuilder().build();
     ExecutorProvider executorProvider = DEFAULT_EXECUTOR_PROVIDER;
     private CredentialsProvider credentialsProvider =
         BigQueryWriteSettings.defaultCredentialsProviderBuilder().build();
@@ -647,7 +671,7 @@ public class StreamWriter implements AutoCloseable {
     }
 
     /** Builds the {@code StreamWriter}. */
-    public StreamWriter build() throws IOException {
+    public StreamWriter build() throws Exception {
       return new StreamWriter(this);
     }
   }
@@ -805,15 +829,17 @@ public class StreamWriter implements AutoCloseable {
     private int batchedBytes;
     private final BatchingSettings batchingSettings;
     private Boolean attachSchema = true;
+    final private String streamName;
 
-    private MessagesBatch(BatchingSettings batchingSettings) {
+    private MessagesBatch(BatchingSettings batchingSettings, String streamName) {
       this.batchingSettings = batchingSettings;
+      this.streamName = streamName;
       reset();
     }
 
     // Get all the messages out in a batch.
     private InflightBatch popBatch() {
-      InflightBatch batch = new InflightBatch(messages, batchedBytes, this.attachSchema);
+      InflightBatch batch = new InflightBatch(messages, batchedBytes, this.streamName, this.attachSchema);
       this.attachSchema = false;
       reset();
       return batch;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
@@ -329,6 +329,7 @@ public class StreamWriter implements AutoCloseable {
   /** Close the stream writer. Shut down all resources. */
   @Override
   public void close() {
+    LOG.info("Closing stream writer");
     shutdown();
     try {
       awaitTermination(1, TimeUnit.MINUTES);

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
@@ -46,17 +46,16 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.threeten.bp.Duration;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.threeten.bp.Duration;
 
 /**
  * A BigQuery Stream Writer that can be used to write data into BigQuery Table.
  *
- * This is to be used to managed streaming write when you are working with PENDING streams or want to explicitly
- * manage offset. In that most common cases when writing with COMMITTED stream without offset, please use a simpler
- * writer {@code DirectWriter}.
+ * <p>This is to be used to managed streaming write when you are working with PENDING streams or
+ * want to explicitly manage offset. In that most common cases when writing with COMMITTED stream
+ * without offset, please use a simpler writer {@code DirectWriter}.
  *
  * <p>A {@link StreamWrier} provides built-in capabilities to: handle batching of messages;
  * controlling memory utilization (through flow control); automatic connection re-establishment and
@@ -75,7 +74,8 @@ import java.util.regex.Pattern;
 public class StreamWriter implements AutoCloseable {
   private static final Logger LOG = Logger.getLogger(StreamWriter.class.getName());
 
-  private static String streamPatternString = "(projects/[^/]+/datasets/[^/]+/tables/[^/]+)/streams/.*";
+  private static String streamPatternString =
+      "(projects/[^/]+/datasets/[^/]+/tables/[^/]+)/streams/.*";
 
   private static Pattern streamPattern = Pattern.compile(streamPatternString);
 
@@ -119,7 +119,8 @@ public class StreamWriter implements AutoCloseable {
   private StreamWriter(Builder builder) throws Exception {
     Matcher matcher = streamPattern.matcher(builder.streamName);
     if (!matcher.matches()) {
-      throw new InvalidArgumentException(null, GrpcStatusCode.of(Status.Code.INVALID_ARGUMENT), false);
+      throw new InvalidArgumentException(
+          null, GrpcStatusCode.of(Status.Code.INVALID_ARGUMENT), false);
     }
     streamName = builder.streamName;
     tableName = matcher.group(1);
@@ -809,7 +810,7 @@ public class StreamWriter implements AutoCloseable {
           try {
             // Establish a new connection.
             streamWriter.refreshAppend();
-          } catch (IOException e) {
+          } catch (IOException | InterruptedException e) {
             LOG.info("Failed to establish a new connection");
           }
         }
@@ -829,7 +830,7 @@ public class StreamWriter implements AutoCloseable {
     private int batchedBytes;
     private final BatchingSettings batchingSettings;
     private Boolean attachSchema = true;
-    final private String streamName;
+    private final String streamName;
 
     private MessagesBatch(BatchingSettings batchingSettings, String streamName) {
       this.batchingSettings = batchingSettings;
@@ -839,7 +840,8 @@ public class StreamWriter implements AutoCloseable {
 
     // Get all the messages out in a batch.
     private InflightBatch popBatch() {
-      InflightBatch batch = new InflightBatch(messages, batchedBytes, this.streamName, this.attachSchema);
+      InflightBatch batch =
+          new InflightBatch(messages, batchedBytes, this.streamName, this.attachSchema);
       this.attachSchema = false;
       reset();
       return batch;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
@@ -121,13 +121,10 @@ public class StreamWriter implements AutoCloseable {
   }
 
   private StreamWriter(Builder builder)
-      throws InvalidArgumentException, IOException, InterruptedException {
+      throws IllegalArgumentException, IOException, InterruptedException {
     Matcher matcher = streamPattern.matcher(builder.streamName);
     if (!matcher.matches()) {
-      throw new InvalidArgumentException(
-          new Exception("Invalid stream name: " + builder.streamName),
-          GrpcStatusCode.of(Status.Code.INVALID_ARGUMENT),
-          false);
+      throw new IllegalArgumentException("Invalid stream name: " + builder.streamName);
     }
     streamName = builder.streamName;
     tableName = matcher.group(1);
@@ -224,7 +221,7 @@ public class StreamWriter implements AutoCloseable {
       setupAlarm();
       if (!batchesToSend.isEmpty()) {
         for (final InflightBatch batch : batchesToSend) {
-          LOG.info("Scheduling a batch for immediate sending.");
+          LOG.fine("Scheduling a batch for immediate sending.");
           writeBatch(batch);
         }
       }
@@ -696,7 +693,7 @@ public class StreamWriter implements AutoCloseable {
     }
 
     /** Builds the {@code StreamWriter}. */
-    public StreamWriter build() throws InvalidArgumentException, IOException, InterruptedException {
+    public StreamWriter build() throws IllegalArgumentException, IOException, InterruptedException {
       return new StreamWriter(this);
     }
   }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCache.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCache.java
@@ -1,0 +1,167 @@
+package com.google.cloud.bigquery.storage.v1alpha2;
+
+import com.google.common.base.Preconditions;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+import javafx.util.Pair;
+import org.threeten.bp.Duration;
+
+/**
+ * A cache of StreamWriters that can be looked up by Table Name. The entries will expire after 5
+ * minutes if not used. Code sample: WriterCache cache = WriterCache.getInstance(); StreamWriter
+ * writer = cache.getWriter(); // Use... cache.returnWriter(writer);
+ */
+public class StreamCache {
+  private static final Logger LOG = Logger.getLogger(StreamCache.class.getName());
+
+  private static StreamCache instance;
+
+  private Duration expireTime = Duration.ofSeconds(300);
+  private ConcurrentHashMap<String, Map<String, Pair<StreamWriter, Long>>> cacheWithTimeout;
+
+  private final BigQueryWriteClient stub;
+  private final BigQueryWriteSettings stubSettings;
+  private final CleanerThread cleanerThread;
+
+  private StreamCache() throws Exception {
+    cacheWithTimeout = new ConcurrentHashMap<>();
+    stubSettings = BigQueryWriteSettings.newBuilder().build();
+    stub = BigQueryWriteClient.create(stubSettings);
+    cleanerThread = new CleanerThread(expireTime.toMillis(), cacheWithTimeout);
+    Executors.newSingleThreadExecutor()
+        .execute(
+            new Runnable() {
+              @Override
+              public void run() {
+                cleanerThread.run();
+              }
+            });
+  }
+
+  public static StreamCache getInstance() throws Exception {
+    if (instance == null) {
+      instance = new StreamCache();
+    }
+    return instance;
+  }
+
+  StreamWriter CreateNewWriter(String tableName) throws Exception {
+    Stream.WriteStream stream =
+        Stream.WriteStream.newBuilder().setType(Stream.WriteStream.Type.COMMITTED).build();
+    stream =
+        stub.createWriteStream(
+            Storage.CreateWriteStreamRequest.newBuilder()
+                .setParent(tableName)
+                .setWriteStream(stream)
+                .build());
+    LOG.info("Created Write Stream:" + stream.getName());
+    return StreamWriter.newBuilder(stream.getName()).build();
+  }
+
+  void addWriterToCache(StreamWriter writer) {
+    Date date = new Date();
+    Pair<StreamWriter, Long> streamEntry = new Pair<>(writer, date.getTime());
+
+    if (!cacheWithTimeout.contains(writer.getTableNameString())) {
+      ConcurrentHashMap<String, Pair<StreamWriter, Long>> tableEntry =
+          new ConcurrentHashMap<String, Pair<StreamWriter, Long>>();
+      tableEntry.put(writer.getStreamNameString(), streamEntry);
+      cacheWithTimeout.put(writer.getTableNameString(), tableEntry);
+    } else {
+      cacheWithTimeout
+          .get(writer.getTableNameString())
+          .put(writer.getStreamNameString(), streamEntry);
+    }
+  }
+
+  /**
+   * Gets a writer for a given table from global cache.
+   *
+   * @param tableName
+   * @return
+   * @throws Exception
+   */
+  public StreamWriter getWriter(String tableName) throws Exception {
+    StreamWriter writer;
+    synchronized (cacheWithTimeout) {
+      if (cacheWithTimeout.contains(tableName)) {
+        Map<String, Pair<StreamWriter, Long>> writersForTable = cacheWithTimeout.get(tableName);
+        Preconditions.checkArgument(!writersForTable.isEmpty());
+        writer = writersForTable.remove(0).getKey();
+        if (writersForTable.isEmpty()) {
+          cacheWithTimeout.remove(tableName);
+        }
+      }
+      writer = CreateNewWriter(tableName);
+      synchronized (cacheWithTimeout) {
+        Date date = new Date();
+        Pair<StreamWriter, Long> streamEntry = new Pair<>(writer, date.getTime());
+        if (!cacheWithTimeout.contains(tableName)) {
+          ConcurrentHashMap<String, Pair<StreamWriter, Long>> tableEntry =
+              new ConcurrentHashMap<String, Pair<StreamWriter, Long>>();
+          tableEntry.put(writer.getStreamNameString(), streamEntry);
+          cacheWithTimeout.put(tableName, tableEntry);
+        } else {
+          cacheWithTimeout.get(tableName).put(writer.getStreamNameString(), streamEntry);
+        }
+      }
+      return writer;
+    }
+  }
+
+  /**
+   * Returns the writer to the cache.
+   *
+   * @param writer
+   */
+  public void returnWriter(StreamWriter writer) {
+    synchronized (cacheWithTimeout) {
+      addWriterToCache(writer);
+    }
+  }
+
+  private class CleanerThread extends Thread {
+    private long expiryInMillis;
+    private ConcurrentHashMap<String, Map<String, Pair<StreamWriter, Long>>> timeMap;
+
+    public CleanerThread(
+        long expirationMillis,
+        ConcurrentHashMap<String, Map<String, Pair<StreamWriter, Long>>> timeMap) {
+      this.expiryInMillis = expirationMillis;
+      this.timeMap = timeMap;
+    }
+
+    @Override
+    public void run() {
+      while (true) {
+        cleanMap();
+        try {
+          Thread.sleep(expiryInMillis / 2);
+        } catch (InterruptedException ignored) {
+        }
+      }
+    }
+
+    private void cleanMap() {
+      long currentTime = new Date().getTime();
+      synchronized (timeMap) {
+        for (String tableName : timeMap.keySet()) {
+          Map<String, Pair<StreamWriter, Long>> tableEntry = timeMap.get(tableName);
+          for (String streamName : tableEntry.keySet()) {
+            if (currentTime > (tableEntry.get(streamName).getValue() + expiryInMillis)) {
+              StreamWriter writer = tableEntry.get(streamName).getKey();
+              writer.close();
+              tableEntry.remove(streamName);
+            }
+          }
+          if (tableEntry.isEmpty()) {
+            timeMap.remove(tableName);
+          }
+        }
+      }
+    }
+  }
+}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
@@ -1,4 +1,3 @@
 package com.google.cloud.bigquery.storage.v1alpha2;
 
-public class DirectWriterTest {
-}
+public class DirectWriterTest {}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
@@ -1,0 +1,4 @@
+package com.google.cloud.bigquery.storage.v1alpha2;
+
+public class DirectWriterTest {
+}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
@@ -1,3 +1,223 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigquery.storage.v1alpha2;
 
-public class DirectWriterTest {}
+import static org.junit.Assert.*;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.cloud.bigquery.storage.test.Test.*;
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Timestamp;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
+
+@RunWith(JUnit4.class)
+public class DirectWriterTest {
+  private static final String TEST_TABLE = "projects/p/datasets/d/tables/t";
+  private static final String TEST_STREAM = "projects/p/datasets/d/tables/t/streams/s";
+  private static final String TEST_STREAM_2 = "projects/p/datasets/d/tables/t/streams/s2";
+
+  private static MockBigQueryWrite mockBigQueryWrite;
+  private static MockServiceHelper serviceHelper;
+  private BigQueryWriteClient client;
+  private LocalChannelProvider channelProvider;
+
+  @BeforeClass
+  public static void startStaticServer() {
+    mockBigQueryWrite = new MockBigQueryWrite();
+    serviceHelper =
+        new MockServiceHelper(
+            UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockBigQueryWrite));
+    serviceHelper.start();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    serviceHelper.stop();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    serviceHelper.reset();
+    channelProvider = serviceHelper.createChannelProvider();
+    BigQueryWriteSettings settings =
+        BigQueryWriteSettings.newBuilder()
+            .setTransportChannelProvider(channelProvider)
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build();
+    client = BigQueryWriteClient.create(settings);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
+  }
+
+  /** Response mocks for create a new writer */
+  void WriterCreationResponseMock(String testStreamName, List<Long> responseOffsets) {
+    // Response from CreateWriteStream
+    Stream.WriteStream expectedResponse =
+        Stream.WriteStream.newBuilder().setName(testStreamName).build();
+    mockBigQueryWrite.addResponse(expectedResponse);
+
+    // Response from GetWriteStream
+    Instant time = Instant.now();
+    Timestamp timestamp =
+        Timestamp.newBuilder().setSeconds(time.getEpochSecond()).setNanos(time.getNano()).build();
+    Stream.WriteStream expectedResponse2 =
+        Stream.WriteStream.newBuilder()
+            .setName(testStreamName)
+            .setType(Stream.WriteStream.Type.COMMITTED)
+            .setCreateTime(timestamp)
+            .build();
+    mockBigQueryWrite.addResponse(expectedResponse2);
+
+    for (Long offset : responseOffsets) {
+      Storage.AppendRowsResponse response =
+          Storage.AppendRowsResponse.newBuilder().setOffset(offset).build();
+      mockBigQueryWrite.addResponse(response);
+    }
+  }
+
+  @Test
+  public void testWriteSuccess() throws Exception {
+    DirectWriter.testSetStub(client, 10);
+    FooType m1 = FooType.newBuilder().setFoo("m1").build();
+    FooType m2 = FooType.newBuilder().setFoo("m2").build();
+
+    WriterCreationResponseMock(TEST_STREAM, Arrays.asList(Long.valueOf(0L)));
+    ApiFuture<Long> ret = DirectWriter.<FooType>append(TEST_TABLE, Arrays.asList(m1, m2));
+    assertEquals(Long.valueOf(0L), ret.get());
+    List<AbstractMessage> actualRequests = mockBigQueryWrite.getRequests();
+    Assert.assertEquals(3, actualRequests.size());
+    assertEquals(
+        TEST_TABLE, ((Storage.CreateWriteStreamRequest) actualRequests.get(0)).getParent());
+    assertEquals(
+        Stream.WriteStream.Type.COMMITTED,
+        ((Storage.CreateWriteStreamRequest) actualRequests.get(0)).getWriteStream().getType());
+    assertEquals(TEST_STREAM, ((Storage.GetWriteStreamRequest) actualRequests.get(1)).getName());
+
+    Storage.AppendRowsRequest.ProtoData.Builder dataBuilder =
+        Storage.AppendRowsRequest.ProtoData.newBuilder();
+    dataBuilder.setWriterSchema(ProtoSchemaConverter.convert(FooType.getDescriptor()));
+    dataBuilder.setRows(
+        ProtoBufProto.ProtoRows.newBuilder()
+            .addSerializedRows(m1.toByteString())
+            .addSerializedRows(m2.toByteString())
+            .build());
+    Storage.AppendRowsRequest expectRequest =
+        Storage.AppendRowsRequest.newBuilder()
+            .setWriteStream(TEST_STREAM)
+            .setProtoRows(dataBuilder.build())
+            .build();
+    assertEquals(expectRequest.toString(), actualRequests.get(2).toString());
+
+    Storage.AppendRowsResponse response =
+        Storage.AppendRowsResponse.newBuilder().setOffset(2).build();
+    mockBigQueryWrite.addResponse(response);
+    // Append again, write stream name and schema are cleared.
+    ret = DirectWriter.<FooType>append(TEST_TABLE, Arrays.asList(m1));
+    assertEquals(Long.valueOf(2L), ret.get());
+    dataBuilder = Storage.AppendRowsRequest.ProtoData.newBuilder();
+    dataBuilder.setRows(
+        ProtoBufProto.ProtoRows.newBuilder().addSerializedRows(m1.toByteString()).build());
+    expectRequest =
+        Storage.AppendRowsRequest.newBuilder().setProtoRows(dataBuilder.build()).build();
+    assertEquals(expectRequest.toString(), actualRequests.get(3).toString());
+
+    // Write with a different schema.
+    WriterCreationResponseMock(TEST_STREAM_2, Arrays.asList(Long.valueOf(0L)));
+    AllSupportedTypes m3 = AllSupportedTypes.newBuilder().setStringValue("s").build();
+    ret = DirectWriter.<AllSupportedTypes>append(TEST_TABLE, Arrays.asList(m3));
+    assertEquals(Long.valueOf(0L), ret.get());
+    dataBuilder = Storage.AppendRowsRequest.ProtoData.newBuilder();
+    dataBuilder.setWriterSchema(ProtoSchemaConverter.convert(AllSupportedTypes.getDescriptor()));
+    dataBuilder.setRows(
+        ProtoBufProto.ProtoRows.newBuilder().addSerializedRows(m3.toByteString()).build());
+    expectRequest =
+        Storage.AppendRowsRequest.newBuilder()
+            .setWriteStream(TEST_STREAM_2)
+            .setProtoRows(dataBuilder.build())
+            .build();
+    Assert.assertEquals(7, actualRequests.size());
+    assertEquals(
+        TEST_TABLE, ((Storage.CreateWriteStreamRequest) actualRequests.get(4)).getParent());
+    assertEquals(
+        Stream.WriteStream.Type.COMMITTED,
+        ((Storage.CreateWriteStreamRequest) actualRequests.get(4)).getWriteStream().getType());
+    assertEquals(TEST_STREAM_2, ((Storage.GetWriteStreamRequest) actualRequests.get(5)).getName());
+    assertEquals(expectRequest.toString(), actualRequests.get(6).toString());
+  }
+
+  @Test
+  public void testWriteBadTableName() throws Exception {
+    DirectWriter.testSetStub(client, 10);
+    FooType m1 = FooType.newBuilder().setFoo("m1").build();
+    FooType m2 = FooType.newBuilder().setFoo("m2").build();
+
+    try {
+      ApiFuture<Long> ret = DirectWriter.<FooType>append("abc", Arrays.asList(m1, m2));
+      fail("should fail");
+    } catch (InvalidArgumentException expected) {
+      assertEquals("java.lang.Exception: Invalid table name: abc", expected.getMessage());
+    }
+  }
+
+  @Test
+  public void testConcurrentAccess() throws Exception {
+    WriterCache cache = WriterCache.getTestInstance(client, 2);
+    final FooType m1 = FooType.newBuilder().setFoo("m1").build();
+    final FooType m2 = FooType.newBuilder().setFoo("m2").build();
+    final List<Long> expectedOffset =
+        Arrays.asList(
+            Long.valueOf(0L),
+            Long.valueOf(2L),
+            Long.valueOf(4L),
+            Long.valueOf(8L),
+            Long.valueOf(10L));
+    // Make sure getting the same table writer in multiple thread only cause create to be called
+    // once.
+    WriterCreationResponseMock(TEST_STREAM, expectedOffset);
+    for (int i = 0; i < 5; i++) {
+      Thread t =
+          new Thread() {
+            @Override
+            public void run() {
+              try {
+                ApiFuture<Long> result =
+                    DirectWriter.<FooType>append(TEST_TABLE, Arrays.asList(m1, m2));
+                assertTrue(expectedOffset.remove(result.get()));
+              } catch (IOException | InterruptedException | ExecutionException e) {
+                fail(e.getMessage());
+              }
+            }
+          };
+      t.start();
+    }
+  }
+}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/FakeBigQueryWrite.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/FakeBigQueryWrite.java
@@ -44,10 +44,16 @@ public class FakeBigQueryWrite implements MockGrpcService {
     return serviceImpl.getCapturedRequests();
   }
 
+  public List<GetWriteStreamRequest> getWriteStreamRequests() {
+    return serviceImpl.getCapturedWriteRequests();
+  }
+
   @Override
   public void addResponse(AbstractMessage response) {
     if (response instanceof AppendRowsResponse) {
       serviceImpl.addResponse((AppendRowsResponse) response);
+    } else if (response instanceof Stream.WriteStream) {
+      serviceImpl.addWriteStreamResponse((Stream.WriteStream) response);
     } else {
       throw new IllegalStateException("Unsupported service");
     }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/MockBigQueryWriteImpl.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/MockBigQueryWriteImpl.java
@@ -83,11 +83,12 @@ public class MockBigQueryWriteImpl extends BigQueryWriteImplBase {
   @Override
   public StreamObserver<AppendRowsRequest> appendRows(
       final StreamObserver<AppendRowsResponse> responseObserver) {
-    final Object response = responses.remove();
     StreamObserver<AppendRowsRequest> requestObserver =
         new StreamObserver<AppendRowsRequest>() {
           @Override
           public void onNext(AppendRowsRequest value) {
+            requests.add(value);
+            final Object response = responses.remove();
             if (response instanceof AppendRowsResponse) {
               responseObserver.onNext((AppendRowsResponse) response);
             } else if (response instanceof Exception) {

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompactTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompactTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.storage.v1alpha2;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.google.cloud.bigquery.*;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.storage.test.Test.FooType;
+import java.io.IOException;
+import javax.annotation.Nullable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class SchemaCompactTest {
+  @Mock private BigQuery mockBigquery;
+  @Mock private Table mockBigqueryTable;
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    when(mockBigquery.getTable(any(TableId.class))).thenReturn(mockBigqueryTable);
+  }
+
+  @After
+  public void tearDown() {
+    verifyNoMoreInteractions(mockBigquery);
+    verifyNoMoreInteractions(mockBigqueryTable);
+  }
+
+  @Test
+  public void testSuccess() throws Exception {
+    TableDefinition definition =
+        new TableDefinition() {
+          @Override
+          public Type getType() {
+            return null;
+          }
+
+          @Nullable
+          @Override
+          public Schema getSchema() {
+            return Schema.of(Field.of("Foo", LegacySQLTypeName.STRING));
+          }
+
+          @Override
+          public Builder toBuilder() {
+            return null;
+          }
+        };
+    when(mockBigqueryTable.getDefinition()).thenReturn(definition);
+    SchemaCompact compact = SchemaCompact.getInstance(mockBigquery);
+    compact.check("projects/p/datasets/d/tables/t", FooType.getDescriptor());
+    verify(mockBigquery, times(1)).getTable(any(TableId.class));
+    verify(mockBigqueryTable, times(1)).getDefinition();
+  }
+
+  @Test
+  public void testFailed() throws Exception {
+    TableDefinition definition =
+        new TableDefinition() {
+          @Override
+          public Type getType() {
+            return null;
+          }
+
+          @Nullable
+          @Override
+          public Schema getSchema() {
+            return Schema.of(
+                Field.of("Foo", LegacySQLTypeName.STRING),
+                Field.of("Bar", LegacySQLTypeName.STRING));
+          }
+
+          @Override
+          public Builder toBuilder() {
+            return null;
+          }
+        };
+    when(mockBigqueryTable.getDefinition()).thenReturn(definition);
+    SchemaCompact compact = SchemaCompact.getInstance(mockBigquery);
+    try {
+      compact.check("projects/p/datasets/d/tables/t", FooType.getDescriptor());
+      fail("should fail");
+    } catch (IllegalArgumentException expected) {
+      assertEquals(
+          "User schema doesn't have expected field number with BigQuery table schema, expected: 2 actual: 1",
+          expected.getMessage());
+    }
+    verify(mockBigquery, times(1)).getTable(any(TableId.class));
+    verify(mockBigqueryTable, times(1)).getDefinition();
+  }
+
+  @Test
+  public void testBadTableName() throws Exception {
+    try {
+      SchemaCompact compact = SchemaCompact.getInstance(mockBigquery);
+      compact.check("blah", FooType.getDescriptor());
+      fail("should fail");
+    } catch (IllegalArgumentException expected) {
+      assertEquals("Invalid table name: blah", expected.getMessage());
+    }
+  }
+}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -82,8 +82,8 @@ public class StreamWriterTest {
         Timestamp.newBuilder().setSeconds(time.getEpochSecond()).setNanos(time.getNano()).build();
     // Add enough GetWriteStream response.
     for (int i = 0; i < 4; i++) {
-	    testBigQueryWrite.addResponse(
-			    Stream.WriteStream.newBuilder().setName(TEST_STREAM).setCreateTime(timestamp).build());
+      testBigQueryWrite.addResponse(
+          Stream.WriteStream.newBuilder().setName(TEST_STREAM).setCreateTime(timestamp).build());
     }
   }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -124,6 +124,12 @@ public class StreamWriterTest {
   }
 
   @Test
+  public void testTableName() throws Exception {
+    StreamWriter writer = getTestStreamWriterBuilder().build();
+    assertEquals("projects/p/datasets/d/tables/t", writer.getTableNameString());
+  }
+
+  @Test
   public void testAppendByDuration() throws Exception {
     StreamWriter writer =
         getTestStreamWriterBuilder()

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -38,6 +38,7 @@ import com.google.cloud.bigquery.storage.test.Test.FooType;
 import com.google.cloud.bigquery.storage.v1alpha2.Storage.*;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Int64Value;
+import com.google.protobuf.Timestamp;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.Arrays;
@@ -53,6 +54,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.threeten.bp.Duration;
+import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class StreamWriterTest {
@@ -75,6 +77,14 @@ public class StreamWriterTest {
     channelProvider = serviceHelper.createChannelProvider();
     fakeExecutor = new FakeScheduledExecutorService();
     testBigQueryWrite.setExecutor(fakeExecutor);
+    Instant time = Instant.now();
+    Timestamp timestamp =
+        Timestamp.newBuilder().setSeconds(time.getEpochSecond()).setNanos(time.getNano()).build();
+    // Add enough GetWriteStream response.
+    for (int i = 0; i < 4; i++) {
+	    testBigQueryWrite.addResponse(
+			    Stream.WriteStream.newBuilder().setName(TEST_STREAM).setCreateTime(timestamp).build());
+    }
   }
 
   @After

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
@@ -1,4 +1,3 @@
 package com.google.cloud.bigquery.storage.v1alpha2;
 
-public class WriterCacheTest {
-}
+public class WriterCacheTest {}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
@@ -1,0 +1,4 @@
+package com.google.cloud.bigquery.storage.v1alpha2;
+
+public class WriterCacheTest {
+}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
@@ -1,3 +1,265 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigquery.storage.v1alpha2;
 
-public class WriterCacheTest {}
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.cloud.bigquery.storage.test.Test.*;
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Timestamp;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
+import org.threeten.bp.temporal.ChronoUnit;
+
+@RunWith(JUnit4.class)
+public class WriterCacheTest {
+  private static final Logger LOG = Logger.getLogger(StreamWriterTest.class.getName());
+
+  private static final String TEST_TABLE = "projects/p/datasets/d/tables/t";
+  private static final String TEST_STREAM = "projects/p/datasets/d/tables/t/streams/s";
+  private static final String TEST_STREAM_2 = "projects/p/datasets/d/tables/t/streams/s2";
+  private static final String TEST_STREAM_3 = "projects/p/datasets/d/tables/t/streams/s3";
+  private static final String TEST_STREAM_4 = "projects/p/datasets/d/tables/t/streams/s4";
+  private static final String TEST_TABLE_2 = "projects/p/datasets/d/tables/t2";
+  private static final String TEST_STREAM_21 = "projects/p/datasets/d/tables/t2/streams/s1";
+  private static final String TEST_TABLE_3 = "projects/p/datasets/d/tables/t3";
+  private static final String TEST_STREAM_31 = "projects/p/datasets/d/tables/t3/streams/s1";
+
+  private static MockBigQueryWrite mockBigQueryWrite;
+  private static MockServiceHelper serviceHelper;
+  private BigQueryWriteClient client;
+  private LocalChannelProvider channelProvider;
+
+  @BeforeClass
+  public static void startStaticServer() {
+    mockBigQueryWrite = new MockBigQueryWrite();
+    serviceHelper =
+        new MockServiceHelper(
+            UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockBigQueryWrite));
+    serviceHelper.start();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    serviceHelper.stop();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    serviceHelper.reset();
+    channelProvider = serviceHelper.createChannelProvider();
+    BigQueryWriteSettings settings =
+        BigQueryWriteSettings.newBuilder()
+            .setTransportChannelProvider(channelProvider)
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build();
+    client = BigQueryWriteClient.create(settings);
+  }
+
+  /** Response mocks for create a new writer */
+  void WriterCreationResponseMock(String testStreamName) {
+    // Response from CreateWriteStream
+    Stream.WriteStream expectedResponse =
+        Stream.WriteStream.newBuilder().setName(testStreamName).build();
+    mockBigQueryWrite.addResponse(expectedResponse);
+
+    // Response from GetWriteStream
+    Instant time = Instant.now();
+    Timestamp timestamp =
+        Timestamp.newBuilder().setSeconds(time.getEpochSecond()).setNanos(time.getNano()).build();
+    Stream.WriteStream expectedResponse2 =
+        Stream.WriteStream.newBuilder()
+            .setName(testStreamName)
+            .setType(Stream.WriteStream.Type.COMMITTED)
+            .setCreateTime(timestamp)
+            .build();
+    mockBigQueryWrite.addResponse(expectedResponse2);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
+  }
+
+  @Test
+  public void testRejectBadTableName() throws Exception {
+    WriterCache cache = WriterCache.getTestInstance(client, 10);
+    try {
+      cache.getTableWriter("abc", FooType.getDescriptor());
+      fail();
+    } catch (InvalidArgumentException expected) {
+      assertEquals(expected.getMessage(), "java.lang.Exception: Invalid table name: abc");
+    }
+  }
+
+  @Test
+  public void testCreateNewWriter() throws Exception {
+    WriterCache cache = WriterCache.getTestInstance(client, 10);
+    WriterCreationResponseMock(TEST_STREAM);
+    StreamWriter writer = cache.getTableWriter(TEST_TABLE, FooType.getDescriptor());
+    List<AbstractMessage> actualRequests = mockBigQueryWrite.getRequests();
+    assertEquals(2, actualRequests.size());
+    assertEquals(
+        TEST_TABLE, ((Storage.CreateWriteStreamRequest) actualRequests.get(0)).getParent());
+    assertEquals(
+        Stream.WriteStream.Type.COMMITTED,
+        ((Storage.CreateWriteStreamRequest) actualRequests.get(0)).getWriteStream().getType());
+    assertEquals(TEST_STREAM, ((Storage.GetWriteStreamRequest) actualRequests.get(1)).getName());
+
+    assertEquals(TEST_TABLE, writer.getTableNameString());
+    assertEquals(TEST_STREAM, writer.getStreamNameString());
+    assertEquals(1, cache.cachedTableCount());
+  }
+
+  @Test
+  public void testWriterExpired() throws Exception {
+    WriterCache cache = WriterCache.getTestInstance(client, 10);
+    // Response from CreateWriteStream
+    Stream.WriteStream expectedResponse =
+        Stream.WriteStream.newBuilder().setName(TEST_STREAM).build();
+    mockBigQueryWrite.addResponse(expectedResponse);
+
+    // Response from GetWriteStream
+    Instant time = Instant.now().minus(2, ChronoUnit.DAYS);
+    Timestamp timestamp =
+        Timestamp.newBuilder().setSeconds(time.getEpochSecond()).setNanos(time.getNano()).build();
+    Stream.WriteStream expectedResponse2 =
+        Stream.WriteStream.newBuilder()
+            .setName(TEST_STREAM)
+            .setType(Stream.WriteStream.Type.COMMITTED)
+            .setCreateTime(timestamp)
+            .build();
+    mockBigQueryWrite.addResponse(expectedResponse2);
+
+    try {
+      StreamWriter writer = cache.getTableWriter(TEST_TABLE, FooType.getDescriptor());
+      fail("Should fail");
+    } catch (IllegalStateException e) {
+      assertEquals(
+          "Cannot write to a stream that is already expired: projects/p/datasets/d/tables/t/streams/s",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testWriterWithNewSchema() throws Exception {
+    WriterCache cache = WriterCache.getTestInstance(client, 10);
+    WriterCreationResponseMock(TEST_STREAM);
+    WriterCreationResponseMock(TEST_STREAM_2);
+    StreamWriter writer1 = cache.getTableWriter(TEST_TABLE, FooType.getDescriptor());
+    StreamWriter writer2 = cache.getTableWriter(TEST_TABLE, AllSupportedTypes.getDescriptor());
+
+    List<AbstractMessage> actualRequests = mockBigQueryWrite.getRequests();
+    assertEquals(4, actualRequests.size());
+    assertEquals(
+        TEST_TABLE, ((Storage.CreateWriteStreamRequest) actualRequests.get(0)).getParent());
+    assertEquals(TEST_STREAM, ((Storage.GetWriteStreamRequest) actualRequests.get(1)).getName());
+    assertEquals(
+        TEST_TABLE, ((Storage.CreateWriteStreamRequest) actualRequests.get(2)).getParent());
+    assertEquals(TEST_STREAM_2, ((Storage.GetWriteStreamRequest) actualRequests.get(3)).getName());
+    assertEquals(TEST_STREAM, writer1.getStreamNameString());
+    assertEquals(TEST_STREAM_2, writer2.getStreamNameString());
+    assertEquals(1, cache.cachedTableCount());
+
+    // Still able to get the FooType writer.
+    StreamWriter writer3 = cache.getTableWriter(TEST_TABLE, FooType.getDescriptor());
+    assertEquals(TEST_STREAM, writer3.getStreamNameString());
+
+    // Create a writer with a even new schema.
+    WriterCreationResponseMock(TEST_STREAM_3);
+    WriterCreationResponseMock(TEST_STREAM_4);
+    StreamWriter writer4 = cache.getTableWriter(TEST_TABLE, NestedType.getDescriptor());
+
+    // This would cause a new stream to be created since the old entry is evicted.
+    StreamWriter writer5 = cache.getTableWriter(TEST_TABLE, AllSupportedTypes.getDescriptor());
+    assertEquals(TEST_STREAM_3, writer4.getStreamNameString());
+    assertEquals(TEST_STREAM_4, writer5.getStreamNameString());
+    assertEquals(1, cache.cachedTableCount());
+  }
+
+  @Test
+  public void testWriterWithDifferentTable() throws Exception {
+    WriterCache cache = WriterCache.getTestInstance(client, 2);
+    WriterCreationResponseMock(TEST_STREAM);
+    WriterCreationResponseMock(TEST_STREAM_21);
+    StreamWriter writer1 = cache.getTableWriter(TEST_TABLE, FooType.getDescriptor());
+    StreamWriter writer2 = cache.getTableWriter(TEST_TABLE_2, FooType.getDescriptor());
+
+    List<AbstractMessage> actualRequests = mockBigQueryWrite.getRequests();
+    assertEquals(4, actualRequests.size());
+    assertEquals(
+        TEST_TABLE, ((Storage.CreateWriteStreamRequest) actualRequests.get(0)).getParent());
+    assertEquals(TEST_STREAM, ((Storage.GetWriteStreamRequest) actualRequests.get(1)).getName());
+    assertEquals(
+        TEST_TABLE_2, ((Storage.CreateWriteStreamRequest) actualRequests.get(2)).getParent());
+    Assert.assertEquals(
+        TEST_STREAM_21, ((Storage.GetWriteStreamRequest) actualRequests.get(3)).getName());
+    assertEquals(TEST_STREAM, writer1.getStreamNameString());
+    assertEquals(TEST_STREAM_21, writer2.getStreamNameString());
+    assertEquals(2, cache.cachedTableCount());
+
+    // Still able to get the FooType writer.
+    StreamWriter writer3 = cache.getTableWriter(TEST_TABLE_2, FooType.getDescriptor());
+    Assert.assertEquals(TEST_STREAM_21, writer3.getStreamNameString());
+
+    // Create a writer with a even new schema.
+    WriterCreationResponseMock(TEST_STREAM_31);
+    WriterCreationResponseMock(TEST_STREAM);
+    StreamWriter writer4 = cache.getTableWriter(TEST_TABLE_3, NestedType.getDescriptor());
+
+    // This would cause a new stream to be created since the old entry is evicted.
+    StreamWriter writer5 = cache.getTableWriter(TEST_TABLE, AllSupportedTypes.getDescriptor());
+    assertEquals(TEST_STREAM_31, writer4.getStreamNameString());
+    assertEquals(TEST_STREAM, writer5.getStreamNameString());
+    assertEquals(2, cache.cachedTableCount());
+  }
+
+  @Test
+  public void testConcurrentAccess() throws Exception {
+    final WriterCache cache = WriterCache.getTestInstance(client, 2);
+    // Make sure getting the same table writer in multiple thread only cause create to be called
+    // once.
+    WriterCreationResponseMock(TEST_STREAM);
+    for (int i = 0; i < 10; i++) {
+      Thread t =
+          new Thread() {
+            @Override
+            public void run() {
+              try {
+                assertTrue(cache.getTableWriter(TEST_TABLE, FooType.getDescriptor()) != null);
+              } catch (IOException | InterruptedException e) {
+                fail(e.getMessage());
+              }
+            }
+          };
+      t.start();
+    }
+  }
+}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/it/ITBigQueryWriteManualClientTest.java
@@ -155,7 +155,8 @@ public class ITBigQueryWriteManualClientTest {
   }
 
   @Test
-  public void testSWBatchWriteWithCommittedStream() throws Exception {
+  public void testBatchWriteWithCommittedStream()
+      throws IOException, InterruptedException, ExecutionException {
     WriteStream writeStream =
         client.createWriteStream(
             CreateWriteStreamRequest.newBuilder()
@@ -201,7 +202,8 @@ public class ITBigQueryWriteManualClientTest {
   }
 
   @Test
-  public void testSWComplicateSchemaWithPendingStream() throws Exception {
+  public void testComplicateSchemaWithPendingStream()
+      throws IOException, InterruptedException, ExecutionException {
     WriteStream writeStream =
         client.createWriteStream(
             CreateWriteStreamRequest.newBuilder()
@@ -264,7 +266,7 @@ public class ITBigQueryWriteManualClientTest {
   }
 
   @Test
-  public void testSWStreamError() throws Exception {
+  public void testStreamError() throws IOException, InterruptedException, ExecutionException {
     WriteStream writeStream =
         client.createWriteStream(
             CreateWriteStreamRequest.newBuilder()
@@ -311,7 +313,7 @@ public class ITBigQueryWriteManualClientTest {
   }
 
   @Test
-  public void testSWStreamReconnect() throws Exception {
+  public void testStreamReconnect() throws IOException, InterruptedException, ExecutionException {
     WriteStream writeStream =
         client.createWriteStream(
             CreateWriteStreamRequest.newBuilder()
@@ -361,7 +363,7 @@ public class ITBigQueryWriteManualClientTest {
   }
 
   @Test
-  public void testDirectWrite() throws Exception {
+  public void testDirectWrite() throws IOException, InterruptedException, ExecutionException {
     final FooType fa = FooType.newBuilder().setFoo("aaa").build();
     final FooType fb = FooType.newBuilder().setFoo("bbb").build();
     Set<Long> expectedOffset = new HashSet<>();


### PR DESCRIPTION
Fixes #164 ☕️

Implementation of DirectWriter which allows users to write to BigQuery in one call. Deduplication is not supported but it should be enough for most common write scenarios.