### PR TITLE
dep: bump google-cloud-bigquery version to 1.111.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery</artifactId>
-        <version>1.110.1</version>
+        <version>1.111.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
dupe of #183 