### PR TITLE
fix: flaky writeapi manual client tests

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
@@ -103,9 +103,7 @@ public class DirectWriter {
     cache = WriterCache.getTestInstance(stub, maxTableEntry, schemaCheck);
   }
 
-  /**
-   * Clears the underlying cache and all the transport connections.
-   */
+  /** Clears the underlying cache and all the transport connections. */
   public static void clearCache() {
     cache.clear();
   }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriter.java
@@ -102,4 +102,11 @@ public class DirectWriter {
       BigQueryWriteClient stub, int maxTableEntry, SchemaCompact schemaCheck) {
     cache = WriterCache.getTestInstance(stub, maxTableEntry, schemaCheck);
   }
+
+  /**
+   * Clears the underlying cache and all the transport connections.
+   */
+  public static void clearCache() {
+    cache.clear();
+  }
 }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCache.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCache.java
@@ -145,6 +145,7 @@ public class WriterCache {
     return writer;
   }
 
+  /** Clear the cache and close all the writers in the cache. */
   public void clear() {
     synchronized (this) {
       ConcurrentMap<String, Cache<Descriptor, StreamWriter>> map = writerCache.asMap();

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCache.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCache.java
@@ -20,6 +20,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.Descriptors.Descriptor;
 import java.io.IOException;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -142,6 +143,21 @@ public class WriterCache {
     }
 
     return writer;
+  }
+
+  public void clear() {
+    synchronized (this) {
+      ConcurrentMap<String, Cache<Descriptor, StreamWriter>> map = writerCache.asMap();
+      for (String key : map.keySet()) {
+        Cache<Descriptor, StreamWriter> entry = writerCache.getIfPresent(key);
+        ConcurrentMap<Descriptor, StreamWriter> entryMap = entry.asMap();
+        for (Descriptor descriptor : entryMap.keySet()) {
+          StreamWriter writer = entry.getIfPresent(descriptor);
+          writer.close();
+        }
+      }
+      writerCache.cleanUp();
+    }
   }
 
   @VisibleForTesting

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -206,14 +205,16 @@ public class DirectWriterTest {
 
   @Test
   public void testConcurrentAccess() throws Exception {
-    DirectWriter.testSetStub(client, 10, schemaCheck);
+    DirectWriter.testSetStub(client, 2, schemaCheck);
     final FooType m1 = FooType.newBuilder().setFoo("m1").build();
     final FooType m2 = FooType.newBuilder().setFoo("m2").build();
-    final Set<Long> expectedOffset = Sets.newHashSet(Long.valueOf(0L),
-    Long.valueOf(2L),
-    Long.valueOf(4L),
-    Long.valueOf(8L),
-    Long.valueOf(10L));
+    final Set<Long> expectedOffset =
+        Sets.newHashSet(
+            Long.valueOf(0L),
+            Long.valueOf(2L),
+            Long.valueOf(4L),
+            Long.valueOf(8L),
+            Long.valueOf(10L));
     // Make sure getting the same table writer in multiple thread only cause create to be called
     // once.
     WriterCreationResponseMock(TEST_STREAM, expectedOffset);

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/DirectWriterTest.java
@@ -24,15 +24,16 @@ import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.cloud.bigquery.storage.test.Test.*;
+import com.google.common.collect.Sets;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Timestamp;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,6 +43,8 @@ import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class DirectWriterTest {
+  private static final Logger LOG = Logger.getLogger(DirectWriterTest.class.getName());
+
   private static final String TEST_TABLE = "projects/p/datasets/d/tables/t";
   private static final String TEST_STREAM = "projects/p/datasets/d/tables/t/streams/s";
   private static final String TEST_STREAM_2 = "projects/p/datasets/d/tables/t/streams/s2";
@@ -86,7 +89,7 @@ public class DirectWriterTest {
   }
 
   /** Response mocks for create a new writer */
-  void WriterCreationResponseMock(String testStreamName, List<Long> responseOffsets) {
+  void WriterCreationResponseMock(String testStreamName, Set<Long> responseOffsets) {
     // Response from CreateWriteStream
     Stream.WriteStream expectedResponse =
         Stream.WriteStream.newBuilder().setName(testStreamName).build();
@@ -117,7 +120,7 @@ public class DirectWriterTest {
     FooType m1 = FooType.newBuilder().setFoo("m1").build();
     FooType m2 = FooType.newBuilder().setFoo("m2").build();
 
-    WriterCreationResponseMock(TEST_STREAM, Arrays.asList(Long.valueOf(0L)));
+    WriterCreationResponseMock(TEST_STREAM, Sets.newHashSet(Long.valueOf(0L)));
     ApiFuture<Long> ret = DirectWriter.<FooType>append(TEST_TABLE, Arrays.asList(m1, m2));
     verify(schemaCheck).check(TEST_TABLE, FooType.getDescriptor());
     assertEquals(Long.valueOf(0L), ret.get());
@@ -159,7 +162,7 @@ public class DirectWriterTest {
     assertEquals(expectRequest.toString(), actualRequests.get(3).toString());
 
     // Write with a different schema.
-    WriterCreationResponseMock(TEST_STREAM_2, Arrays.asList(Long.valueOf(0L)));
+    WriterCreationResponseMock(TEST_STREAM_2, Sets.newHashSet(Long.valueOf(0L)));
     AllSupportedTypes m3 = AllSupportedTypes.newBuilder().setStringValue("s").build();
     ret = DirectWriter.<AllSupportedTypes>append(TEST_TABLE, Arrays.asList(m3));
     verify(schemaCheck).check(TEST_TABLE, AllSupportedTypes.getDescriptor());
@@ -181,6 +184,8 @@ public class DirectWriterTest {
         ((Storage.CreateWriteStreamRequest) actualRequests.get(4)).getWriteStream().getType());
     assertEquals(TEST_STREAM_2, ((Storage.GetWriteStreamRequest) actualRequests.get(5)).getName());
     assertEquals(expectRequest.toString(), actualRequests.get(6).toString());
+
+    DirectWriter.clearCache();
   }
 
   @Test
@@ -195,20 +200,20 @@ public class DirectWriterTest {
     } catch (IllegalArgumentException expected) {
       assertEquals("Invalid table name: abc", expected.getMessage());
     }
+
+    DirectWriter.clearCache();
   }
 
   @Test
   public void testConcurrentAccess() throws Exception {
-    WriterCache cache = WriterCache.getTestInstance(client, 2, schemaCheck);
+    DirectWriter.testSetStub(client, 10, schemaCheck);
     final FooType m1 = FooType.newBuilder().setFoo("m1").build();
     final FooType m2 = FooType.newBuilder().setFoo("m2").build();
-    final List<Long> expectedOffset =
-        Arrays.asList(
-            Long.valueOf(0L),
-            Long.valueOf(2L),
-            Long.valueOf(4L),
-            Long.valueOf(8L),
-            Long.valueOf(10L));
+    final Set<Long> expectedOffset = Sets.newHashSet(Long.valueOf(0L),
+    Long.valueOf(2L),
+    Long.valueOf(4L),
+    Long.valueOf(8L),
+    Long.valueOf(10L));
     // Make sure getting the same table writer in multiple thread only cause create to be called
     // once.
     WriterCreationResponseMock(TEST_STREAM, expectedOffset);
@@ -221,12 +226,21 @@ public class DirectWriterTest {
               try {
                 ApiFuture<Long> result =
                     DirectWriter.<FooType>append(TEST_TABLE, Arrays.asList(m1, m2));
-                assertTrue(expectedOffset.remove(result.get()));
-              } catch (IOException | InterruptedException | ExecutionException e) {
-                fail(e.getMessage());
+                synchronized (expectedOffset) {
+                  assertTrue(expectedOffset.remove(result.get()));
+                }
+              } catch (Exception e) {
+                fail(e.toString());
               }
             }
           });
     }
+    executor.shutdown();
+    try {
+      executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+    } catch (InterruptedException e) {
+      LOG.info(e.toString());
+    }
+    DirectWriter.clearCache();
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -430,7 +430,8 @@ public class StreamWriterTest {
       try {
         appendFuture2.get();
         Assert.fail("This should fail");
-      } catch (ExecutionException e) {
+      } catch (Exception e) {
+        LOG.info("ControlFlow test exception: " + e.toString());
         assertEquals("The maximum number of batch elements: 1 have been reached.", e.getMessage());
       }
       assertEquals(1L, appendFuture1.get().getOffset());

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -135,8 +135,9 @@ public class StreamWriterTest {
 
   @Test
   public void testTableName() throws Exception {
-    StreamWriter writer = getTestStreamWriterBuilder().build();
-    assertEquals("projects/p/datasets/d/tables/t", writer.getTableNameString());
+    try (StreamWriter writer = getTestStreamWriterBuilder().build()) {
+      assertEquals("projects/p/datasets/d/tables/t", writer.getTableNameString());
+    }
   }
 
   @Test
@@ -175,7 +176,7 @@ public class StreamWriterTest {
             .getSerializedRowsCount());
     assertEquals(
         true, testBigQueryWrite.getAppendRequests().get(0).getProtoRows().hasWriterSchema());
-    writer.shutdown();
+    writer.close();
   }
 
   @Test
@@ -228,7 +229,7 @@ public class StreamWriterTest {
             .getSerializedRowsCount());
     assertEquals(
         false, testBigQueryWrite.getAppendRequests().get(1).getProtoRows().hasWriterSchema());
-    writer.shutdown();
+    writer.close();
   }
 
   @Test
@@ -264,7 +265,7 @@ public class StreamWriterTest {
 
     assertEquals(3, testBigQueryWrite.getAppendRequests().size());
 
-    writer.shutdown();
+    writer.close();
   }
 
   @Test

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/WriterCacheTest.java
@@ -143,6 +143,7 @@ public class WriterCacheTest {
     assertEquals(TEST_TABLE, writer.getTableNameString());
     assertEquals(TEST_STREAM, writer.getStreamNameString());
     assertEquals(1, cache.cachedTableCount());
+    cache.clear();
   }
 
   @Test
@@ -173,6 +174,7 @@ public class WriterCacheTest {
           "Cannot write to a stream that is already expired: projects/p/datasets/d/tables/t/streams/s",
           e.getMessage());
     }
+    cache.clear();
   }
 
   @Test
@@ -216,6 +218,7 @@ public class WriterCacheTest {
     assertEquals(TEST_STREAM_3, writer4.getStreamNameString());
     assertEquals(TEST_STREAM_4, writer5.getStreamNameString());
     assertEquals(1, cache.cachedTableCount());
+    cache.clear();
   }
 
   @Test
@@ -259,6 +262,7 @@ public class WriterCacheTest {
     assertEquals(TEST_STREAM_31, writer4.getStreamNameString());
     assertEquals(TEST_STREAM, writer5.getStreamNameString());
     assertEquals(2, cache.cachedTableCount());
+    cache.clear();
   }
 
   @Test
@@ -275,7 +279,7 @@ public class WriterCacheTest {
             public void run() {
               try {
                 assertTrue(cache.getTableWriter(TEST_TABLE, FooType.getDescriptor()) != null);
-              } catch (IOException | InterruptedException e) {
+              } catch (Exception e) {
                 fail(e.getMessage());
               }
             }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/it/ITBigQueryWriteManualClientTest.java
@@ -391,5 +391,12 @@ public class ITBigQueryWriteManualClientTest {
       assertTrue(expectedOffset.remove(response.get()));
     }
     assertTrue(expectedOffset.isEmpty());
+    executor.shutdown();
+    try {
+      executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+    } catch (InterruptedException e) {
+      LOG.info(e.toString());
+    }
+    DirectWriter.clearCache();
   }
 }


### PR DESCRIPTION
1. There are some warnings in the test runs saying that open connections are not closed. Make sure everything is shutdown after test.
2. There is some unexpected exceptions thrown which is not caught. Now catch a more general exception and also fix some issues that incorrectly calling remove on List (which is not supported).
3. Make sure the executor in the tests are finished running, so it will not run into a race with test shutdown.
