### PR TITLE
fix:Add more logging to investigate transient test failure.

### DIFF
--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -429,8 +429,14 @@ public class StreamWriterTest {
       try {
         appendFuture2.get();
         Assert.fail("This should fail");
-      } catch (ExecutionException e) {
-        assertEquals("The maximum number of batch elements: 1 have been reached.", e.getMessage());
+      } catch (Exception e) {
+        if (!e.getMessage().equals("The maximum number of batch elements: 1 have been reached.")) {
+          LOG.info("More error info:");
+          e.printStackTrace();
+        }
+        assertEquals(
+            "java.util.concurrent.ExecutionException: The maximum number of batch elements: 1 have been reached.",
+            e.toString());
       }
       assertEquals(1L, appendFuture1.get().getOffset());
     }


### PR DESCRIPTION
Investigate why test failed with:
[ERROR] Failures:
4820[ERROR] StreamWriterTest.testFlowControlBehaviorException:436 expected:<[The maximum number of batch elements: 1 have been reached.]> but was:<[com.google.api.gax.rpc.UnknownException: io.grpc.StatusRuntimeException: UNKNOWN]>

I don't know where the exception is thrown.
