### PR TITLE
feat: Add flush API to StreamWriter

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
@@ -245,6 +245,29 @@ public class StreamWriter implements AutoCloseable {
   }
 
   /**
+   * Flush the rows on a BUFFERED stream, up to the specified offset. After flush, rows will be
+   * available for read. If no exception is thrown, it means the flush happened.
+   *
+   * <p>NOTE: Currently the implementation is void, BUFFERED steam acts like COMMITTED stream. It is
+   * just for Dataflow team to mock the usage.
+   *
+   * @param offset Offset to which the rows will be committed to the system. It must fall within the
+   *     row counts on the stream.
+   * @throws IllegalArgumentException if offset is invalid
+   */
+  public void flush(long offset) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("Invalid offset: " + offset);
+    }
+    // TODO: Once we persisted stream type, we should check the call can only be issued on BUFFERED
+    // stream here.
+    Storage.FlushRowsRequest request =
+        Storage.FlushRowsRequest.newBuilder().setWriteStream(streamName).setOffset(offset).build();
+    stub.flushRows(request);
+    // TODO: We will verify if the returned offset is equal to requested offset.
+  }
+
+  /**
    * Re-establishes a stream connection.
    *
    * @throws IOException

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/FakeBigQueryWrite.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/FakeBigQueryWrite.java
@@ -54,6 +54,8 @@ public class FakeBigQueryWrite implements MockGrpcService {
       serviceImpl.addResponse((AppendRowsResponse) response);
     } else if (response instanceof Stream.WriteStream) {
       serviceImpl.addWriteStreamResponse((Stream.WriteStream) response);
+    } else if (response instanceof FlushRowsResponse) {
+      serviceImpl.addFlushRowsResponse((FlushRowsResponse) response);
     } else {
       throw new IllegalStateException("Unsupported service");
     }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/it/ITBigQueryWriteManualClientTest.java
@@ -402,10 +402,21 @@ public class ITBigQueryWriteManualClientTest {
 
   @Test
   public void testFlushRows() throws IOException, InterruptedException, ExecutionException {
+    String tableName = "BufferTable";
+    TableInfo tableInfo =
+        TableInfo.newBuilder(
+                TableId.of(DATASET, tableName),
+                StandardTableDefinition.of(
+                    Schema.of(
+                        com.google.cloud.bigquery.Field.newBuilder("foo", LegacySQLTypeName.STRING)
+                            .build())))
+            .build();
+    bigquery.create(tableInfo);
+    TableName parent = TableName.of(ServiceOptions.getDefaultProjectId(), DATASET, tableName);
     WriteStream writeStream =
         client.createWriteStream(
             CreateWriteStreamRequest.newBuilder()
-                .setParent(tableId)
+                .setParent(parent.toString())
                 .setWriteStream(WriteStream.newBuilder().setType(WriteStream.Type.BUFFERED).build())
                 .build());
     try (StreamWriter streamWriter = StreamWriter.newBuilder(writeStream.getName()).build()) {


### PR DESCRIPTION
Add a flush method to StreamWriter. The implementation is void, so just added boilerplate unit test and e2e test.