### PR TITLE
fix: try to make test run a bit faster, and update some logs.

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriter.java
@@ -146,7 +146,6 @@ public class StreamWriter implements AutoCloseable {
       stubSettings =
           BigQueryWriteSettings.newBuilder()
               .setCredentialsProvider(builder.credentialsProvider)
-              .setExecutorProvider(builder.executorProvider)
               .setTransportChannelProvider(builder.channelProvider)
               .setEndpoint(builder.endpoint)
               .build();
@@ -250,7 +249,6 @@ public class StreamWriter implements AutoCloseable {
    * @throws IOException
    */
   public void refreshAppend() throws IOException, InterruptedException {
-    LOG.info("Establish a write connection.");
     synchronized (this) {
       if (shutdown.get()) {
         LOG.warning("Cannot refresh on a already shutdown writer.");
@@ -258,7 +256,7 @@ public class StreamWriter implements AutoCloseable {
       }
       // There could be a moment, stub is not yet initialized.
       if (clientStream != null) {
-        LOG.info("Closing the stream");
+        LOG.info("Closing the stream " + streamName);
         clientStream.closeSend();
       }
       messagesBatch.resetAttachSchema();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -516,7 +516,7 @@ public class StreamWriterTest {
     StatusRuntimeException transientError = new StatusRuntimeException(Status.UNAVAILABLE);
     testBigQueryWrite.addException(transientError);
     testBigQueryWrite.addException(transientError);
-    ApiFuture<AppendRowsResponse> future3 = sendTestMessage(writer, new String[] {"m3"});
+    ApiFuture<AppendRowsResponse> future3 = sendTestMessage(writer, new String[] {"toomanyretry"});
     try {
       future3.get();
       Assert.fail("This should fail.");
@@ -821,12 +821,11 @@ public class StreamWriterTest {
 
   @Test
   public void testAwaitTermination() throws Exception {
-    StreamWriter writer =
-        getTestStreamWriterBuilder().setExecutorProvider(SINGLE_THREAD_EXECUTOR).build();
+    StreamWriter writer = getTestStreamWriterBuilder().build();
     testBigQueryWrite.addResponse(AppendRowsResponse.newBuilder().build());
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     writer.shutdown();
-    assertTrue(writer.awaitTermination(2, TimeUnit.MINUTES));
+    assertTrue(writer.awaitTermination(1, TimeUnit.MINUTES));
   }
 
   @Test


### PR DESCRIPTION
Make custom executor no longer pass down to BigQueryWriteClient. The user have a choice of setting a custom BigQueryWriteClient nowadays. The custom executor will only be used in the scope of StreamWriter. This will reduce one test run time by 1 minute.