### PR TITLE
fix: Add some logging to investigate why we keep retrying instead of stopping at max retries

### DIFF
--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+    <!--TODO: To be removed-->
+    <difference>
+        <differenceType>7009</differenceType>
+        <className>com/google/cloud/bigquery/storage/v1alpha2/StreamWriter</className>
+        <method>void shutdown()</method>
+    </difference>
+    <difference>
+        <differenceType>7009</differenceType>
+        <className>com/google/cloud/bigquery/storage/v1alpha2/StreamWriter</className>
+        <method>boolean awaitTermination(long, java.util.concurrent.TimeUnit) </method>
+    </difference>
+</differences>

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -294,8 +294,7 @@ public class StreamWriterTest {
     // Note we are not advancing time or reaching the count threshold but messages should
     // still get written by call to shutdown
 
-    writer.shutdown();
-    writer.awaitTermination(10, TimeUnit.SECONDS);
+    writer.close();
 
     // Verify the appends completed
     assertTrue(appendFuture1.isDone());
@@ -407,8 +406,7 @@ public class StreamWriterTest {
     // Wait is necessary for response to be scheduled before timer is advanced.
     fakeExecutor.advanceTime(Duration.ofSeconds(10));
     t.join();
-    writer.shutdown();
-    writer.awaitTermination(1, TimeUnit.MINUTES);
+    writer.close();
   }
 
   @Test
@@ -527,8 +525,7 @@ public class StreamWriterTest {
     } catch (ExecutionException e) {
       assertEquals(transientError.toString(), e.getCause().getCause().toString());
     }
-    writer.shutdown();
-    assertTrue(writer.awaitTermination(1, TimeUnit.MINUTES));
+    writer.close();
   }
 
   @Test
@@ -643,7 +640,7 @@ public class StreamWriterTest {
             .getFlowControlSettings()
             .getMaxOutstandingRequestBytes()
             .longValue());
-    writer.shutdown();
+    writer.close();
   }
 
   @Test
@@ -820,29 +817,6 @@ public class StreamWriterTest {
       fail("Should have thrown an NullPointerException");
     } catch (NullPointerException expected) {
       // Expected
-    }
-  }
-
-  @Test
-  public void testAwaitTermination() throws Exception {
-    StreamWriter writer =
-        getTestStreamWriterBuilder("projects/p/datasets/d/tables/t/streams/await").build();
-    testBigQueryWrite.addResponse(AppendRowsResponse.newBuilder().build());
-    ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"AWAIT"});
-    writer.shutdown();
-    assertTrue(writer.awaitTermination(1, TimeUnit.MINUTES));
-  }
-
-  @Test
-  public void testClose() throws Exception {
-    StreamWriter writer = getTestStreamWriterBuilder().build();
-    writer.close();
-    try {
-      writer.shutdown();
-      fail("Should throw");
-    } catch (IllegalStateException e) {
-      LOG.info(e.toString());
-      assertEquals("Cannot shut down a writer already shut-down.", e.getMessage());
     }
   }
 


### PR DESCRIPTION
There is a test failing because we didn't stop retrying at max retry numbers. I couldn't repro it on my local machine.

Switch the order of resetting current retries and set the exceptions on response and add some logging.