### PR TITLE
fix: BQ Numeric is compatible with double and float protobuf types

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompatibility.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompatibility.java
@@ -205,6 +205,11 @@ public class SchemaCompatibility {
     if (field == Descriptors.FieldDescriptor.Type.BYTES) {
       return true;
     }
+    
+    if (field == Descriptors.FieldDescriptor.Type.FLOAT ||
+        field == Descriptors.FieldDescriptor.Type.DOUBLE) {
+      return true;
+    }
 
     return false;
   }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompatibility.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompatibility.java
@@ -205,9 +205,9 @@ public class SchemaCompatibility {
     if (field == Descriptors.FieldDescriptor.Type.BYTES) {
       return true;
     }
-    
-    if (field == Descriptors.FieldDescriptor.Type.FLOAT ||
-        field == Descriptors.FieldDescriptor.Type.DOUBLE) {
+
+    if (field == Descriptors.FieldDescriptor.Type.FLOAT
+        || field == Descriptors.FieldDescriptor.Type.DOUBLE) {
       return true;
     }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompatibilityTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/SchemaCompatibilityTest.java
@@ -729,7 +729,9 @@ public class SchemaCompatibilityTest {
                 Fixed64Type.getDescriptor(),
                 SFixed32Type.getDescriptor(),
                 SFixed64Type.getDescriptor(),
-                BytesType.getDescriptor()));
+                BytesType.getDescriptor(),
+                FloatType.getDescriptor(),
+                DoubleType.getDescriptor()));
 
     for (Descriptors.Descriptor descriptor : type_descriptors) {
       if (compatible.contains(descriptor)) {


### PR DESCRIPTION
Fixed a bug and made BQ Numeric compatible with double and float protobuf types.