### PR TITLE
fix: BQTableSchemaToProtobufDescriptor will now only generate lower-cased fieldnames in the protobuf descriptor

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptor.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptor.java
@@ -28,8 +28,9 @@ import java.util.HashMap;
 import java.util.List;
 
 /**
- * Converts a BQ table schema to protobuf descriptor. The mapping between field types and field
- * modes are shown in the ImmutableMaps below.
+ * Converts a BQ table schema to protobuf descriptor. All field names will be converted to lowercase
+ * when constructing the protobuf descriptor. The mapping between field types and field modes are
+ * shown in the ImmutableMaps below.
  */
 public class BQTableSchemaToProtoDescriptor {
   private static ImmutableMap<Table.TableFieldSchema.Mode, FieldDescriptorProto.Label>
@@ -130,7 +131,7 @@ public class BQTableSchemaToProtoDescriptor {
   private static FieldDescriptorProto convertBQTableFieldToProtoField(
       Table.TableFieldSchema BQTableField, int index, String scope) {
     Table.TableFieldSchema.Mode mode = BQTableField.getMode();
-    String fieldName = BQTableField.getName();
+    String fieldName = BQTableField.getName().toLowerCase();
     if (BQTableField.getType() == Table.TableFieldSchema.Type.STRUCT) {
       return FieldDescriptorProto.newBuilder()
           .setName(fieldName)

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
@@ -274,7 +274,7 @@ public class BQTableSchemaToProtoDescriptorTest {
             .build();
     final Descriptor descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(tableSchema);
-    // isDescriptorEqual(descriptor, CasingComplex.getDescriptor());
+    isDescriptorEqual(descriptor, CasingComplex.getDescriptor());
   }
 
   @Test

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
@@ -274,7 +274,7 @@ public class BQTableSchemaToProtoDescriptorTest {
             .build();
     final Descriptor descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(tableSchema);
-    isDescriptorEqual(descriptor, CasingComplex.getDescriptor());
+    // isDescriptorEqual(descriptor, CasingComplex.getDescriptor());
   }
 
   @Test

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
@@ -171,7 +171,7 @@ public class BQTableSchemaToProtoDescriptorTest {
             .setType(Table.TableFieldSchema.Type.STRUCT)
             .setMode(Table.TableFieldSchema.Mode.REQUIRED)
             .addFields(0, test_int)
-            .setName("complexLvl2")
+            .setName("complex_lvl2")
             .build();
     final Table.TableFieldSchema ComplexLvl1 =
         Table.TableFieldSchema.newBuilder()
@@ -179,7 +179,7 @@ public class BQTableSchemaToProtoDescriptorTest {
             .setMode(Table.TableFieldSchema.Mode.REQUIRED)
             .addFields(0, test_int)
             .addFields(1, ComplexLvl2)
-            .setName("complexLvl1")
+            .setName("complex_lvl1")
             .build();
     final Table.TableSchema tableSchema =
         Table.TableSchema.newBuilder()
@@ -195,6 +195,87 @@ public class BQTableSchemaToProtoDescriptorTest {
     final Descriptor descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(tableSchema);
     isDescriptorEqual(descriptor, ComplexRoot.getDescriptor());
+  }
+
+  @Test
+  public void testCasingComplexStruct() throws Exception {
+    final Table.TableFieldSchema required =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.INT64)
+            .setMode(Table.TableFieldSchema.Mode.REQUIRED)
+            .setName("tEsT_ReQuIrEd")
+            .build();
+    final Table.TableFieldSchema repeated =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.INT64)
+            .setMode(Table.TableFieldSchema.Mode.REPEATED)
+            .setName("tESt_repEATed")
+            .build();
+    final Table.TableFieldSchema optional =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.INT64)
+            .setMode(Table.TableFieldSchema.Mode.NULLABLE)
+            .setName("test_opTIONal")
+            .build();
+    final Table.TableFieldSchema test_int =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.INT64)
+            .setMode(Table.TableFieldSchema.Mode.NULLABLE)
+            .setName("TEST_INT")
+            .build();
+    final Table.TableFieldSchema test_string =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.STRING)
+            .setMode(Table.TableFieldSchema.Mode.REPEATED)
+            .setName("TEST_STRING")
+            .build();
+    final Table.TableFieldSchema test_bytes =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.BYTES)
+            .setMode(Table.TableFieldSchema.Mode.REQUIRED)
+            .setName("TEST_BYTES")
+            .build();
+    final Table.TableFieldSchema test_bool =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.BOOL)
+            .setMode(Table.TableFieldSchema.Mode.NULLABLE)
+            .setName("TEST_BOOL")
+            .build();
+    final Table.TableFieldSchema test_double =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.DOUBLE)
+            .setMode(Table.TableFieldSchema.Mode.REPEATED)
+            .setName("TEST_DOUBLE")
+            .build();
+    final Table.TableFieldSchema test_date =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.DATE)
+            .setMode(Table.TableFieldSchema.Mode.REQUIRED)
+            .setName("TEST_DATE")
+            .build();
+    final Table.TableFieldSchema option_test =
+        Table.TableFieldSchema.newBuilder()
+            .setType(Table.TableFieldSchema.Type.STRUCT)
+            .setMode(Table.TableFieldSchema.Mode.REQUIRED)
+            .addFields(0, required)
+            .addFields(1, repeated)
+            .addFields(2, optional)
+            .setName("option_test")
+            .build();
+    final Table.TableSchema tableSchema =
+        Table.TableSchema.newBuilder()
+            .addFields(0, test_int)
+            .addFields(1, test_string)
+            .addFields(2, test_bytes)
+            .addFields(3, test_bool)
+            .addFields(4, test_double)
+            .addFields(5, test_date)
+            .addFields(6, option_test)
+            .build();
+    final Descriptor descriptor =
+        BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(tableSchema);
+    isDescriptorEqual(descriptor, CasingComplex.getDescriptor());
+    System.out.println(descriptor.toProto());
   }
 
   @Test

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/BQTableSchemaToProtoDescriptorTest.java
@@ -275,7 +275,6 @@ public class BQTableSchemaToProtoDescriptorTest {
     final Descriptor descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(tableSchema);
     isDescriptorEqual(descriptor, CasingComplex.getDescriptor());
-    System.out.println(descriptor.toProto());
   }
 
   @Test

--- a/google-cloud-bigquerystorage/src/test/proto/jsonTest.proto
+++ b/google-cloud-bigquerystorage/src/test/proto/jsonTest.proto
@@ -9,13 +9,23 @@ message ComplexRoot {
   optional bool test_bool = 4;
   repeated double test_double = 5;
   required int32 test_date = 6;
-  required ComplexLvl1 complexLvl1 = 7;
-  required ComplexLvl2 complexLvl2 = 8;
+  required ComplexLvl1 complex_lvl1 = 7;
+  required ComplexLvl2 complex_lvl2 = 8;
+}
+
+message CasingComplex {
+  optional int64 test_int = 1;
+  repeated string test_string = 2;
+  required bytes test_bytes = 3;
+  optional bool test_bool = 4;
+  repeated double test_double = 5;
+  required int32 test_date = 6;
+  required OptionTest option_test = 7;
 }
 
 message ComplexLvl1 {
   optional int64 test_int = 1;
-  required ComplexLvl2 complexLvl2 = 2;
+  required ComplexLvl2 complex_lvl2 = 2;
 }
 
 message ComplexLvl2 {


### PR DESCRIPTION
Since the backend is case-insensitive, letting all fieldnames be lowercased in the generated protobuf descriptor can save some space/time while using the generated descriptor to create a protobuf message from JSON.