### PR TITLE
fix: add missing resource name deps to v1beta1

### DIFF
--- a/proto-google-cloud-bigquerystorage-v1beta1/pom.xml
+++ b/proto-google-cloud-bigquerystorage-v1beta1/pom.xml
@@ -21,6 +21,14 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
These dependencies were not added to the `pom.xml` by the generator when resource name classes were added. I'm not sure why that is, but it will fix the CI errors in #435. I tested this locally and noted it in the config change.