### PR TITLE
chore: exclude org.apache.commons:commons-lang3 from renovate-bot updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,9 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
+    },
+    {
+      "excludePackageNames": ["org.apache.commons"]
     }
   ],
   "semanticCommits": true,

--- a/synth.py
+++ b/synth.py
@@ -36,5 +36,5 @@ for version in versions:
   )
 
 java.common_templates(excludes=[
-    '.kokoro/build.bat' # TODO: remove this when we switch to actions
+    'renovate.json' # excluding due to common-lang3 dep added to renovate.json
 ])


### PR DESCRIPTION
it's not java7 compat

this allows us to permanently close #545 

