### PR TITLE
feat: remove IgnoreUnknownFields support on JsonStreamWriter

### DIFF
--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+    <!-- TODO(stephwang): To be removed after the release -->
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter</className>
+        <differenceType>7005</differenceType>
+        <method>com.google.api.core.ApiFuture append(org.json.JSONArray, boolean)</method>
+        <from>com.google.api.core.ApiFuture append(org.json.JSONArray, boolean)</from>
+        <to>com.google.api.core.ApiFuture append(org.json.JSONArray, long)</to>
+    </difference>
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter</className>
+        <differenceType>7004</differenceType>
+        <method>com.google.api.core.ApiFuture append(org.json.JSONArray, long, boolean)</method>
+        <from>com.google.api.core.ApiFuture append(org.json.JSONArray, long, boolean)</from>
+        <to>com.google.api.core.ApiFuture append(org.json.JSONArray)</to>
+    </difference>
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessage</className>
+        <differenceType>7004</differenceType>
+        <method>com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject, boolean)</method>
+        <from>com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject, boolean)</from>
+        <to>com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject)</to>
+    </difference>
+</differences>

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
@@ -94,12 +94,11 @@ public class JsonStreamWriter implements AutoCloseable {
    * schema update, the OnSchemaUpdateRunnable will be used to determine what actions to perform.
    *
    * @param jsonArr The JSON array that contains JSONObjects to be written
-   * @param allowUnknownFields if true, json data can have fields unknown to the BigQuery table.
    * @return ApiFuture<AppendRowsResponse> returns an AppendRowsResponse message wrapped in an
    *     ApiFuture
    */
-  public ApiFuture<AppendRowsResponse> append(JSONArray jsonArr, boolean allowUnknownFields) {
-    return append(jsonArr, -1, allowUnknownFields);
+  public ApiFuture<AppendRowsResponse> append(JSONArray jsonArr) {
+    return append(jsonArr, -1);
   }
 
   /**
@@ -109,20 +108,17 @@ public class JsonStreamWriter implements AutoCloseable {
    *
    * @param jsonArr The JSON array that contains JSONObjects to be written
    * @param offset Offset for deduplication
-   * @param allowUnknownFields if true, json data can have fields unknown to the BigQuery table.
    * @return ApiFuture<AppendRowsResponse> returns an AppendRowsResponse message wrapped in an
    *     ApiFuture
    */
-  public ApiFuture<AppendRowsResponse> append(
-      JSONArray jsonArr, long offset, boolean allowUnknownFields) {
+  public ApiFuture<AppendRowsResponse> append(JSONArray jsonArr, long offset) {
     ProtoRows.Builder rowsBuilder = ProtoRows.newBuilder();
     // Any error in convertJsonToProtoMessage will throw an
     // IllegalArgumentException/IllegalStateException/NullPointerException and will halt processing
     // of JSON data.
     for (int i = 0; i < jsonArr.length(); i++) {
       JSONObject json = jsonArr.getJSONObject(i);
-      Message protoMessage =
-          JsonToProtoMessage.convertJsonToProtoMessage(this.descriptor, json, allowUnknownFields);
+      Message protoMessage = JsonToProtoMessage.convertJsonToProtoMessage(this.descriptor, json);
       rowsBuilder.addSerializedRows(protoMessage.toByteString());
     }
     AppendRowsRequest.ProtoData.Builder data = AppendRowsRequest.ProtoData.newBuilder();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/StreamWriterTest.java
@@ -876,6 +876,8 @@ public class StreamWriterTest {
             .build();
 
     testBigQueryWrite.addException(Status.DATA_LOSS.asException());
+    testBigQueryWrite.addException(Status.DATA_LOSS.asException());
+    testBigQueryWrite.addException(Status.DATA_LOSS.asException());
 
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"B"});

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriterTest.java
@@ -251,8 +251,7 @@ public class JsonStreamWriterTest {
                   AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
               .build());
 
-      ApiFuture<AppendRowsResponse> appendFuture =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
       assertEquals(0L, appendFuture.get().getAppendResult().getOffset().getValue());
       appendFuture.get();
       assertEquals(
@@ -299,8 +298,7 @@ public class JsonStreamWriterTest {
                   AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
               .build());
 
-      ApiFuture<AppendRowsResponse> appendFuture =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
 
       assertEquals(0L, appendFuture.get().getAppendResult().getOffset().getValue());
       appendFuture.get();
@@ -357,7 +355,7 @@ public class JsonStreamWriterTest {
               .build());
       ApiFuture<AppendRowsResponse> appendFuture;
       for (int i = 0; i < 4; i++) {
-        appendFuture = writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+        appendFuture = writer.append(jsonArr);
         assertEquals((long) i, appendFuture.get().getAppendResult().getOffset().getValue());
         appendFuture.get();
         assertEquals(
@@ -443,8 +441,7 @@ public class JsonStreamWriterTest {
                   AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
               .build());
 
-      ApiFuture<AppendRowsResponse> appendFuture =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
 
       assertEquals(0L, appendFuture.get().getAppendResult().getOffset().getValue());
       appendFuture.get();
@@ -495,8 +492,7 @@ public class JsonStreamWriterTest {
       JSONArray jsonArr = new JSONArray();
       jsonArr.put(foo);
 
-      ApiFuture<AppendRowsResponse> appendFuture1 =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture1 = writer.append(jsonArr);
 
       int millis = 0;
       while (millis <= 10000) {
@@ -532,8 +528,7 @@ public class JsonStreamWriterTest {
       JSONArray updatedJsonArr = new JSONArray();
       updatedJsonArr.put(updatedFoo);
 
-      ApiFuture<AppendRowsResponse> appendFuture2 =
-          writer.append(updatedJsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(updatedJsonArr);
 
       millis = 0;
       while (millis <= 10000) {
@@ -570,8 +565,7 @@ public class JsonStreamWriterTest {
       JSONArray updatedJsonArr2 = new JSONArray();
       updatedJsonArr2.put(updatedFoo2);
 
-      ApiFuture<AppendRowsResponse> appendFuture3 =
-          writer.append(updatedJsonArr2, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture3 = writer.append(updatedJsonArr2);
 
       assertEquals(2L, appendFuture3.get().getAppendResult().getOffset().getValue());
       assertEquals(
@@ -614,8 +608,7 @@ public class JsonStreamWriterTest {
       foo.put("foo", "allen");
       JSONArray jsonArr = new JSONArray();
       jsonArr.put(foo);
-      ApiFuture<AppendRowsResponse> appendFuture =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
       try {
         appendFuture.get();
         Assert.fail("expected ExecutionException");
@@ -644,8 +637,7 @@ public class JsonStreamWriterTest {
       foo.put("foo", "allen");
       JSONArray jsonArr = new JSONArray();
       jsonArr.put(foo);
-      ApiFuture<AppendRowsResponse> appendFuture =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
       try {
         appendFuture.get();
         Assert.fail("expected ExecutionException");
@@ -668,8 +660,7 @@ public class JsonStreamWriterTest {
       JSONArray updatedJsonArr = new JSONArray();
       updatedJsonArr.put(updatedFoo);
 
-      ApiFuture<AppendRowsResponse> appendFuture2 =
-          writer.append(updatedJsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(updatedJsonArr);
       assertEquals(0L, appendFuture2.get().getAppendResult().getOffset().getValue());
       appendFuture2.get();
       assertEquals(
@@ -727,12 +718,9 @@ public class JsonStreamWriterTest {
       JSONArray jsonArr = new JSONArray();
       jsonArr.put(foo);
 
-      ApiFuture<AppendRowsResponse> appendFuture1 =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
-      ApiFuture<AppendRowsResponse> appendFuture2 =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
-      ApiFuture<AppendRowsResponse> appendFuture3 =
-          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture1 = writer.append(jsonArr);
+      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(jsonArr);
+      ApiFuture<AppendRowsResponse> appendFuture3 = writer.append(jsonArr);
 
       assertEquals(0L, appendFuture1.get().getAppendResult().getOffset().getValue());
       assertEquals(1L, appendFuture2.get().getAppendResult().getOffset().getValue());
@@ -796,8 +784,7 @@ public class JsonStreamWriterTest {
       JSONArray updatedJsonArr = new JSONArray();
       updatedJsonArr.put(updatedFoo);
 
-      ApiFuture<AppendRowsResponse> appendFuture4 =
-          writer.append(updatedJsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> appendFuture4 = writer.append(updatedJsonArr);
 
       assertEquals(3L, appendFuture4.get().getAppendResult().getOffset().getValue());
       assertEquals(
@@ -857,8 +844,7 @@ public class JsonStreamWriterTest {
                 new Runnable() {
                   public void run() {
                     try {
-                      ApiFuture<AppendRowsResponse> appendFuture =
-                          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+                      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
                       AppendRowsResponse response = appendFuture.get();
                       offsetSets.remove(response.getAppendResult().getOffset().getValue());
                     } catch (Exception e) {
@@ -940,8 +926,7 @@ public class JsonStreamWriterTest {
                 new Runnable() {
                   public void run() {
                     try {
-                      ApiFuture<AppendRowsResponse> appendFuture =
-                          writer.append(jsonArr, -1, /* allowUnknownFields */ false);
+                      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
                       AppendRowsResponse response = appendFuture.get();
                       offsetSets.remove(response.getAppendResult().getOffset().getValue());
                     } catch (Exception e) {
@@ -1004,8 +989,7 @@ public class JsonStreamWriterTest {
                 new Runnable() {
                   public void run() {
                     try {
-                      ApiFuture<AppendRowsResponse> appendFuture =
-                          writer.append(jsonArr2, -1, /* allowUnknownFields */ false);
+                      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr2);
                       AppendRowsResponse response = appendFuture.get();
                       offsetSets.remove(response.getAppendResult().getOffset().getValue());
                     } catch (Exception e) {

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessageTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -264,8 +265,8 @@ public class JsonToProtoMessageTest {
     json.put("inT", 1);
     json.put("lONg", 1L);
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -278,8 +279,8 @@ public class JsonToProtoMessageTest {
     json.put("int", 1);
     json.put("long", 1L);
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -290,8 +291,8 @@ public class JsonToProtoMessageTest {
     json.put("short", (short) 1);
     json.put("int", 1);
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(TestInt32.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(TestInt32.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -302,9 +303,10 @@ public class JsonToProtoMessageTest {
     json.put("int", 1L);
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(TestInt32.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(TestInt32.getDescriptor(), json);
+      Assert.fail("should fail");
     } catch (IllegalArgumentException e) {
-      assertEquals(e.getMessage(), "JSONObject does not have a int32 field at root.int.");
+      assertEquals("JSONObject does not have a int32 field at root.int.", e.getMessage());
     }
   }
 
@@ -315,8 +317,8 @@ public class JsonToProtoMessageTest {
     json.put("double", 1.2);
     json.put("float", 3.4f);
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(TestDouble.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(TestDouble.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -326,13 +328,13 @@ public class JsonToProtoMessageTest {
       for (JSONObject json : simpleJSONObjects) {
         try {
           DynamicMessage protoMsg =
-              JsonToProtoMessage.convertJsonToProtoMessage(entry.getKey(), json, false);
+              JsonToProtoMessage.convertJsonToProtoMessage(entry.getKey(), json);
           assertEquals(protoMsg, AllTypesToCorrectProto.get(entry.getKey())[success]);
           success += 1;
         } catch (IllegalArgumentException e) {
           assertEquals(
-              e.getMessage(),
-              "JSONObject does not have a " + entry.getValue() + " field at root.test_field_type.");
+              "JSONObject does not have a " + entry.getValue() + " field at root.test_field_type.",
+              e.getMessage());
         }
       }
       if (entry.getKey() == Int64Type.getDescriptor()) {
@@ -350,15 +352,13 @@ public class JsonToProtoMessageTest {
       for (JSONObject json : simpleJSONArrays) {
         try {
           DynamicMessage protoMsg =
-              JsonToProtoMessage.convertJsonToProtoMessage(entry.getKey(), json, false);
+              JsonToProtoMessage.convertJsonToProtoMessage(entry.getKey(), json);
           assertEquals(protoMsg, AllRepeatedTypesToCorrectProto.get(entry.getKey())[success]);
           success += 1;
         } catch (IllegalArgumentException e) {
           assertEquals(
-              e.getMessage(),
-              "JSONObject does not have a "
-                  + entry.getValue()
-                  + " field at root.test_repeated[0].");
+              "JSONObject does not have a " + entry.getValue() + " field at root.test_repeated[0].",
+              e.getMessage());
         }
       }
       if (entry.getKey() == RepeatedInt64.getDescriptor()
@@ -377,8 +377,8 @@ public class JsonToProtoMessageTest {
     json.put("byte", 1);
 
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -389,9 +389,8 @@ public class JsonToProtoMessageTest {
     json.put("required_double", 1.1);
 
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(
-            TestRepeatedIsOptional.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(TestRepeatedIsOptional.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -400,10 +399,11 @@ public class JsonToProtoMessageTest {
     json.put("optional_double", 1.1);
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(TestRequired.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(TestRequired.getDescriptor(), json);
+      Assert.fail("should fail");
     } catch (IllegalArgumentException e) {
       assertEquals(
-          e.getMessage(), "JSONObject does not have the required field root.required_double.");
+          "JSONObject does not have the required field root.required_double.", e.getMessage());
     }
   }
 
@@ -419,8 +419,8 @@ public class JsonToProtoMessageTest {
     json.put("test_field_type", stringType);
 
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(MessageType.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(MessageType.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -431,11 +431,12 @@ public class JsonToProtoMessageTest {
     json.put("test_field_type", stringType);
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(MessageType.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(MessageType.getDescriptor(), json);
+      Assert.fail("should fail");
     } catch (IllegalArgumentException e) {
       assertEquals(
-          e.getMessage(),
-          "JSONObject does not have a string field at root.test_field_type.test_field_type.");
+          "JSONObject does not have a string field at root.test_field_type.test_field_type.",
+          e.getMessage());
     }
   }
 
@@ -479,8 +480,8 @@ public class JsonToProtoMessageTest {
     json.put("complex_lvl2", complex_lvl2);
 
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(ComplexRoot.getDescriptor(), json, false);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(ComplexRoot.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -504,10 +505,11 @@ public class JsonToProtoMessageTest {
 
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(ComplexRoot.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(ComplexRoot.getDescriptor(), json);
+      Assert.fail("should fail");
     } catch (IllegalArgumentException e) {
       assertEquals(
-          e.getMessage(), "JSONObject does not have a int64 field at root.complex_lvl1.test_int.");
+          "JSONObject does not have a int64 field at root.complex_lvl1.test_int.", e.getMessage());
     }
   }
 
@@ -517,10 +519,11 @@ public class JsonToProtoMessageTest {
     json.put("test_repeated", new JSONArray("[1.1, 2.2, true]"));
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(RepeatedDouble.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(RepeatedDouble.getDescriptor(), json);
+      Assert.fail("should fail");
     } catch (IllegalArgumentException e) {
       assertEquals(
-          e.getMessage(), "JSONObject does not have a double field at root.test_repeated[2].");
+          "JSONObject does not have a double field at root.test_repeated[2].", e.getMessage());
     }
   }
 
@@ -559,7 +562,7 @@ public class JsonToProtoMessageTest {
     json.put("repeated_string", jsonRepeatedString);
 
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(NestedRepeated.getDescriptor(), json, false);
+        JsonToProtoMessage.convertJsonToProtoMessage(NestedRepeated.getDescriptor(), json);
     assertEquals(protoMsg, expectedProto);
   }
 
@@ -578,31 +581,13 @@ public class JsonToProtoMessageTest {
 
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(NestedRepeated.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(NestedRepeated.getDescriptor(), json);
+      Assert.fail("should fail");
     } catch (IllegalArgumentException e) {
       assertEquals(
-          e.getMessage(),
-          "JSONObject does not have a string field at root.repeated_string.test_repeated[0].");
+          "JSONObject does not have a string field at root.repeated_string.test_repeated[0].",
+          e.getMessage());
     }
-  }
-
-  @Test
-  public void testAllowUnknownFields() throws Exception {
-    RepeatedInt64 expectedProto =
-        RepeatedInt64.newBuilder()
-            .addTestRepeated(1)
-            .addTestRepeated(2)
-            .addTestRepeated(3)
-            .addTestRepeated(4)
-            .addTestRepeated(5)
-            .build();
-    JSONObject json = new JSONObject();
-    json.put("test_repeated", new JSONArray(new int[] {1, 2, 3, 4, 5}));
-    json.put("string", "hello");
-
-    DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(RepeatedInt64.getDescriptor(), json, true);
-    assertEquals(protoMsg, expectedProto);
   }
 
   @Test
@@ -618,8 +603,8 @@ public class JsonToProtoMessageTest {
     json.put("complex_lvl2", complexLvl2);
 
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(ComplexLvl1.getDescriptor(), json, true);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(ComplexLvl1.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -630,11 +615,10 @@ public class JsonToProtoMessageTest {
 
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(RepeatedInt64.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(RepeatedInt64.getDescriptor(), json);
+      Assert.fail("Should fail");
     } catch (IllegalArgumentException e) {
-      assertEquals(
-          e.getMessage(),
-          "JSONObject has fields unknown to BigQuery: root.string. Set allowUnknownFields to True to allow unknown fields.");
+      assertEquals("JSONObject has fields unknown to BigQuery: root.string.", e.getMessage());
     }
   }
 
@@ -642,13 +626,13 @@ public class JsonToProtoMessageTest {
   public void testEmptyProtoMessage() throws Exception {
     JSONObject json = new JSONObject();
     json.put("test_repeated", new JSONArray(new int[0]));
-    json.put("string", "hello");
 
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(RepeatedInt64.getDescriptor(), json, true);
+          JsonToProtoMessage.convertJsonToProtoMessage(RepeatedInt64.getDescriptor(), json);
+      Assert.fail("Should fail");
     } catch (IllegalArgumentException e) {
-      assertEquals(e.getMessage(), "The created protobuf message is empty.");
+      assertEquals("The created protobuf message is empty.", e.getMessage());
     }
   }
 
@@ -657,9 +641,10 @@ public class JsonToProtoMessageTest {
     JSONObject json = new JSONObject();
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(Int64Type.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(Int64Type.getDescriptor(), json);
+      Assert.fail("Should fail");
     } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "JSONObject is empty.");
+      assertEquals("JSONObject is empty.", e.getMessage());
     }
   }
 
@@ -667,9 +652,10 @@ public class JsonToProtoMessageTest {
   public void testNullJson() throws Exception {
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(Int64Type.getDescriptor(), null, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(Int64Type.getDescriptor(), null);
+      Assert.fail("Should fail");
     } catch (NullPointerException e) {
-      assertEquals(e.getMessage(), "JSONObject is null.");
+      assertEquals("JSONObject is null.", e.getMessage());
     }
   }
 
@@ -677,9 +663,10 @@ public class JsonToProtoMessageTest {
   public void testNullDescriptor() throws Exception {
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(null, new JSONObject(), false);
+          JsonToProtoMessage.convertJsonToProtoMessage(null, new JSONObject());
+      Assert.fail("Should fail");
     } catch (NullPointerException e) {
-      assertEquals(e.getMessage(), "Protobuf descriptor is null.");
+      assertEquals("Protobuf descriptor is null.", e.getMessage());
     }
   }
 
@@ -693,27 +680,11 @@ public class JsonToProtoMessageTest {
 
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(ComplexLvl1.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(ComplexLvl1.getDescriptor(), json);
+      Assert.fail("Should fail");
     } catch (IllegalArgumentException e) {
       assertEquals(
-          e.getMessage(),
-          "JSONObject has fields unknown to BigQuery: root.complex_lvl2.no_match. Set allowUnknownFields to True to allow unknown fields.");
-    }
-  }
-
-  @Test
-  public void testTopLevelMismatch() throws Exception {
-    JSONObject json = new JSONObject();
-    json.put("no_match", 1.1);
-
-    try {
-      DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(
-              TopLevelMismatch.getDescriptor(), json, true);
-    } catch (IllegalArgumentException e) {
-      assertEquals(
-          e.getMessage(),
-          "There are no matching fields found for the JSONObject and the protocol buffer descriptor.");
+          "JSONObject has fields unknown to BigQuery: root.complex_lvl2.no_match.", e.getMessage());
     }
   }
 
@@ -725,14 +696,13 @@ public class JsonToProtoMessageTest {
             .setComplexLvl2(ComplexLvl2.newBuilder().build())
             .build();
     JSONObject complex_lvl2 = new JSONObject();
-    complex_lvl2.put("no_match", 1);
     JSONObject json = new JSONObject();
     json.put("test_int", 1);
     json.put("complex_lvl2", complex_lvl2);
 
     DynamicMessage protoMsg =
-        JsonToProtoMessage.convertJsonToProtoMessage(ComplexLvl1.getDescriptor(), json, true);
-    assertEquals(protoMsg, expectedProto);
+        JsonToProtoMessage.convertJsonToProtoMessage(ComplexLvl1.getDescriptor(), json);
+    assertEquals(expectedProto, protoMsg);
   }
 
   @Test
@@ -742,7 +712,8 @@ public class JsonToProtoMessageTest {
     json.put("int", 1);
     try {
       DynamicMessage protoMsg =
-          JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json, false);
+          JsonToProtoMessage.convertJsonToProtoMessage(TestInt64.getDescriptor(), json);
+      Assert.fail("Should fail");
     } catch (IllegalArgumentException e) {
       assertEquals(e.getMessage(), "JSONObject does not have a int64 field at root.long.");
     }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -958,6 +958,8 @@ public class StreamWriterTest {
             .build();
 
     testBigQueryWrite.addException(Status.DATA_LOSS.asException());
+    testBigQueryWrite.addException(Status.DATA_LOSS.asException());
+    testBigQueryWrite.addException(Status.DATA_LOSS.asException());
 
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"B"});

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryWriteManualClientTest.java
@@ -251,8 +251,7 @@ public class ITBigQueryWriteManualClientTest {
       row1.put("test_datetime", "2020-10-1 12:00:00");
       JSONArray jsonArr1 = new JSONArray(new JSONObject[] {row1});
 
-      ApiFuture<AppendRowsResponse> response1 =
-          jsonStreamWriter.append(jsonArr1, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> response1 = jsonStreamWriter.append(jsonArr1, -1);
 
       assertEquals(0, response1.get().getAppendResult().getOffset().getValue());
 
@@ -270,11 +269,9 @@ public class ITBigQueryWriteManualClientTest {
       jsonArr3.put(row4);
 
       LOG.info("Sending two more messages");
-      ApiFuture<AppendRowsResponse> response2 =
-          jsonStreamWriter.append(jsonArr2, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> response2 = jsonStreamWriter.append(jsonArr2, -1);
       LOG.info("Sending one more message");
-      ApiFuture<AppendRowsResponse> response3 =
-          jsonStreamWriter.append(jsonArr3, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> response3 = jsonStreamWriter.append(jsonArr3, -1);
       assertEquals(1, response2.get().getAppendResult().getOffset().getValue());
       assertEquals(3, response3.get().getAppendResult().getOffset().getValue());
 
@@ -331,8 +328,7 @@ public class ITBigQueryWriteManualClientTest {
       JSONArray jsonArr = new JSONArray();
       jsonArr.put(foo);
 
-      ApiFuture<AppendRowsResponse> response =
-          jsonStreamWriter.append(jsonArr, -1, /* allowUnknownFields */ false);
+      ApiFuture<AppendRowsResponse> response = jsonStreamWriter.append(jsonArr, -1);
       assertEquals(0, response.get().getAppendResult().getOffset().getValue());
       // 2). Schema update and wait until querying it returns a new schema.
       try {
@@ -375,8 +371,7 @@ public class ITBigQueryWriteManualClientTest {
 
       int next = 0;
       for (int i = 1; i < 100; i++) {
-        ApiFuture<AppendRowsResponse> response2 =
-            jsonStreamWriter.append(jsonArr2, -1, /* allowUnknownFields */ false);
+        ApiFuture<AppendRowsResponse> response2 = jsonStreamWriter.append(jsonArr2, -1);
         assertEquals(i, response2.get().getAppendResult().getOffset().getValue());
         if (response2.get().hasUpdatedSchema()) {
           next = i;
@@ -403,8 +398,7 @@ public class ITBigQueryWriteManualClientTest {
       JSONArray updatedJsonArr = new JSONArray();
       updatedJsonArr.put(updatedFoo);
       for (int i = 0; i < 10; i++) {
-        ApiFuture<AppendRowsResponse> response3 =
-            jsonStreamWriter.append(updatedJsonArr, -1, /* allowUnknownFields */ false);
+        ApiFuture<AppendRowsResponse> response3 = jsonStreamWriter.append(updatedJsonArr, -1);
         assertEquals(next + 1 + i, response3.get().getAppendResult().getOffset().getValue());
         response3.get();
       }

--- a/proto-google-cloud-bigquerystorage-v1beta2/clirr-ignored-differences.xml
+++ b/proto-google-cloud-bigquerystorage-v1beta2/clirr-ignored-differences.xml
@@ -173,26 +173,4 @@
         <differenceType>7012</differenceType>
         <method>java.util.List getStreamErrorsOrBuilderList()</method>
     </difference>
-
-    <difference>
-        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter</className>
-        <differenceType>7005</differenceType>
-        <method>public com.google.api.core.ApiFuture append(org.json.JSONArray, boolean)</method>
-        <from>public com.google.api.core.ApiFuture append(org.json.JSONArray, boolean)</from>
-        <to>public com.google.api.core.ApiFuture append(org.json.JSONArray, long)</to>
-    </difference>
-    <difference>
-        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter</className>
-        <differenceType>7004</differenceType>
-        <method>public com.google.api.core.ApiFuture append(org.json.JSONArray, long, boolean)</method>
-        <from>public com.google.api.core.ApiFuture append(org.json.JSONArray, long, boolean)</from>
-        <to>public com.google.api.core.ApiFuture append(org.json.JSONArray)</to>
-    </difference>
-    <difference>
-        <className>com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessage</className>
-        <differenceType>7004</differenceType>
-        <method>public com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject, boolean)</method>
-        <from>public com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject, boolean)</from>
-        <to>public com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject)</to>
-    </difference>
 </differences>

--- a/proto-google-cloud-bigquerystorage-v1beta2/clirr-ignored-differences.xml
+++ b/proto-google-cloud-bigquerystorage-v1beta2/clirr-ignored-differences.xml
@@ -173,4 +173,26 @@
         <differenceType>7012</differenceType>
         <method>java.util.List getStreamErrorsOrBuilderList()</method>
     </difference>
+
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter</className>
+        <differenceType>7005</differenceType>
+        <method>public com.google.api.core.ApiFuture append(org.json.JSONArray, boolean)</method>
+        <from>public com.google.api.core.ApiFuture append(org.json.JSONArray, boolean)</from>
+        <to>public com.google.api.core.ApiFuture append(org.json.JSONArray, long)</to>
+    </difference>
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter</className>
+        <differenceType>7004</differenceType>
+        <method>public com.google.api.core.ApiFuture append(org.json.JSONArray, long, boolean)</method>
+        <from>public com.google.api.core.ApiFuture append(org.json.JSONArray, long, boolean)</from>
+        <to>public com.google.api.core.ApiFuture append(org.json.JSONArray)</to>
+    </difference>
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessage</className>
+        <differenceType>7004</differenceType>
+        <method>public com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject, boolean)</method>
+        <from>public com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject, boolean)</from>
+        <to>public com.google.protobuf.DynamicMessage convertJsonToProtoMessage(com.google.protobuf.Descriptors$Descriptor, org.json.JSONObject)</to>
+    </difference>
 </differences>


### PR DESCRIPTION
Original PR opened by @yirutang : https://github.com/googleapis/java-bigquerystorage/pull/755

IgnoreUnknownFields is no longer supported on API level. So make JsonStreamWriter consistent with it.