### PR TITLE
fix:shutdown stuck when there is error on the flush path

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -932,6 +932,7 @@ public class StreamWriter implements AutoCloseable {
     public void onError(Throwable t) {
       LOG.fine("OnError called");
       if (streamWriter.shutdown.get()) {
+        abortInflightRequests(t);
         return;
       }
       InflightBatch inflightBatch = null;

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -1015,4 +1015,37 @@ public class StreamWriterTest {
     assertEquals("Dataflow", testBigQueryWrite.getAppendRequests().get(0).getTraceId());
     assertEquals("", testBigQueryWrite.getAppendRequests().get(1).getTraceId());
   }
+
+  @Test
+  public void testShutdownWithConnectionError() throws Exception {
+    StreamWriter writer =
+        getTestStreamWriterBuilder()
+            .setBatchingSettings(
+                StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
+                    .toBuilder()
+                    .setElementCountThreshold(1L)
+                    .build())
+            .build();
+    testBigQueryWrite.addResponse(
+        AppendRowsResponse.newBuilder()
+            .setAppendResult(
+                AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(1)).build())
+            .build());
+    testBigQueryWrite.addException(Status.DATA_LOSS.asException());
+    testBigQueryWrite.setResponseDelay(Duration.ofSeconds(10));
+
+    ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
+    ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"B"});
+    Thread.sleep(5000L);
+    fakeExecutor.advanceTime(Duration.ofSeconds(20));
+    // Shutdown writer immediately and there will be some error happened when flushing the queue.
+    writer.shutdown();
+    assertEquals(1, appendFuture1.get().getAppendResult().getOffset().getValue());
+    try {
+      appendFuture2.get();
+      fail("Should fail with exception");
+    } catch (java.util.concurrent.ExecutionException e) {
+      LOG.info("got: " + e.toString());
+    }
+  }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -1037,6 +1037,7 @@ public class StreamWriterTest {
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"B"});
     Thread.sleep(5000L);
+    // Move the needle for responses to be sent.
     fakeExecutor.advanceTime(Duration.ofSeconds(20));
     // Shutdown writer immediately and there will be some error happened when flushing the queue.
     writer.shutdown();
@@ -1045,7 +1046,7 @@ public class StreamWriterTest {
       appendFuture2.get();
       fail("Should fail with exception");
     } catch (java.util.concurrent.ExecutionException e) {
-      LOG.info("got: " + e.toString());
+      assertEquals("Request aborted due to previous failures", e.getCause().getMessage());
     }
   }
 }


### PR DESCRIPTION
…l to release the requests in the queue, causing shutdown to wait forever

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
