### PR TITLE
fix: retry+inflight limit+multiple requests in inflight queue

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -328,7 +328,6 @@ public class StreamWriter implements AutoCloseable {
       }
     }
     Thread.sleep(this.retrySettings.getInitialRetryDelay().toMillis());
-    LOG.info("Sending request");
     responseObserver.resendInflightBatch();
     LOG.info("Write Stream " + streamName + " connection established");
   }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -830,7 +830,9 @@ public class StreamWriter implements AutoCloseable {
           AppendRowsRequest request = batch.getMergedRequest();
           try {
             this.streamWriter.messagesWaiter.acquire(batch.getByteSize());
-            this.streamWriter.clientStream.send(request);
+            synchronized (this.streamWriter.clientStream) {
+              this.streamWriter.clientStream.send(request);
+            }
           } catch (FlowController.FlowControlException ex) {
             batch.onFailure(ex);
           }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -353,7 +353,6 @@ public class StreamWriter implements AutoCloseable {
     if (!messagesBatch.isEmpty()) {
       writeBatch(messagesBatch.popBatch());
     }
-    messagesBatch.reset();
   }
 
   private void writeBatch(final InflightBatch inflightBatch) {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
@@ -77,13 +77,12 @@ class Waiter {
     lock.lock();
     pendingCount = 0;
     pendingSize = 0;
-    notifyNextAcquires();
     lock.unlock();
-    notifyAll();
   }
 
   public void acquire(long messageSize) throws FlowController.FlowControlException {
     lock.lock();
+    LOG.info("pendingCount:" + pendingCount);
     try {
       if (pendingCount >= countLimit
           && behavior == FlowController.LimitExceededBehavior.ThrowException) {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
@@ -73,6 +73,8 @@ class Waiter {
     notifyAll();
   }
 
+  // This clearAll is used only for when we are reestablish connections. It will not notify the current waiters, so
+  // we can prevent appends that are waiting on the queue to occupy inflight quota.
   public synchronized void clearAll() {
     lock.lock();
     pendingCount = 0;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
@@ -73,6 +73,15 @@ class Waiter {
     notifyAll();
   }
 
+  public synchronized void clearAll() {
+    lock.lock();
+    pendingCount = 0;
+    pendingSize = 0;
+    notifyNextAcquires();
+    lock.unlock();
+    notifyAll();
+  }
+
   public void acquire(long messageSize) throws FlowController.FlowControlException {
     lock.lock();
     try {

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -1108,7 +1108,7 @@ public class StreamWriterTest {
       appendFuture2.get();
       fail("Should fail with exception");
     } catch (java.util.concurrent.ExecutionException e) {
-      assertEquals("Request aborted due to previous failures", e.getCause().getMessage());
+      assertEquals("io.grpc.StatusRuntimeException: DATA_LOSS", e.getCause().getMessage());
     }
   }
 }


### PR DESCRIPTION
Fix an issue when we are close to inflight limit and there are multiple requests waiting in the queue and we are trying. Previous code had a problem of only resending the first request in the queue. There are multiple fixes in this CL:
1. Move the locks to be more specific and has a smaller range:
  - Remove MessageBatchLock (changed to lock only on messages)
  - Remove RefreshAndAppendLock (changed to lock only on clientStreams)
2. Simplify the reconnection code a little bit by remove the top inflight batch code.
3. Add function to resend all inflight queue to the newly established connection.

Added two test cases to test the situation indicated in the title. Let me know if you prefer the split up the CLs.
