### PR TITLE
fix: remove reconnection feature from client library

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -65,8 +65,7 @@ import org.threeten.bp.Duration;
  * without offset, please use a simpler writer {@code DirectWriter}.
  *
  * <p>A {@link StreamWrier} provides built-in capabilities to: handle batching of messages;
- * controlling memory utilization (through flow control); automatic connection re-establishment and
- * request cleanup (only keeps write schema on first request in the stream).
+ * controlling memory utilization (through flow control); request cleanup (only keeps write schema on first request in the stream).
  *
  * <p>With customizable options that control:
  *
@@ -496,6 +495,7 @@ public class StreamWriter implements AutoCloseable {
         return;
       } else {
         LOG.info("Setting " + t.toString() + " on response");
+        streamWriter.messagesWaiter.release(this.getByteSize());
         this.streamWriter.setException(t);
       }
 
@@ -871,7 +871,6 @@ public class StreamWriter implements AutoCloseable {
                   t,
                   GrpcStatusCode.of(Status.Code.ABORTED),
                   true));
-          streamWriter.messagesWaiter.release(inflightBatch.getByteSize());
         }
       }
     }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -919,11 +919,12 @@ public class StreamWriter implements AutoCloseable {
                         response.getAppendResult().getOffset().getValue(),
                         inflightBatch.getExpectedOffset()));
             inflightBatch.onFailure(exception);
-            abortInflightRequests(new AbortedException(
-                "Request aborted due to previous failures",
-                exception,
-                GrpcStatusCode.of(Status.Code.ABORTED),
-                true));
+            abortInflightRequests(
+                new AbortedException(
+                    "Request aborted due to previous failures",
+                    exception,
+                    GrpcStatusCode.of(Status.Code.ABORTED),
+                    true));
           } else {
             inflightBatch.onSuccess(response);
           }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -65,7 +65,8 @@ import org.threeten.bp.Duration;
  * without offset, please use a simpler writer {@code DirectWriter}.
  *
  * <p>A {@link StreamWrier} provides built-in capabilities to: handle batching of messages;
- * controlling memory utilization (through flow control); request cleanup (only keeps write schema on first request in the stream).
+ * controlling memory utilization (through flow control); request cleanup (only keeps write schema
+ * on first request in the stream).
  *
  * <p>With customizable options that control:
  *

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -868,7 +868,7 @@ public class StreamWriter implements AutoCloseable {
           InflightBatch inflightBatch = this.inflightBatches.poll();
           if (first_error) {
             inflightBatch.onFailure(t);
-            first_error = true;
+            first_error = false;
           } else {
             inflightBatch.onFailure(
                 new AbortedException(

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/Waiter.java
@@ -64,10 +64,16 @@ class Waiter {
     }
   }
 
-  public synchronized void release(long messageSize) {
+  public synchronized void release(long messageSize) throws IllegalStateException {
     lock.lock();
     --pendingCount;
+    if (pendingCount < 0) {
+      throw new IllegalStateException("pendingCount cannot be less than 0");
+    }
     pendingSize -= messageSize;
+    if (pendingSize < 0) {
+      throw new IllegalStateException("pendingSize cannot be less than 0");
+    }
     notifyNextAcquires();
     lock.unlock();
     notifyAll();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -942,7 +942,7 @@ public class StreamWriterTest {
       appendFuture2.get();
       fail("Should fail with exception");
     } catch (java.util.concurrent.ExecutionException e) {
-      assertEquals("Request aborted due to previous failures", e.getCause().getMessage());
+      assertEquals("io.grpc.StatusRuntimeException: DATA_LOSS", e.getCause().getMessage());
     }
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -955,13 +955,13 @@ public class StreamWriterTest {
       appendFuture2.get();
       fail("Should fail with exception future2");
     } catch (java.util.concurrent.ExecutionException e) {
-      assertEquals("io.grpc.StatusRuntimeException: DATA_LOSS", e.getCause().getMessage());
+      assertThat(e.getCause()).isInstanceOf(DataLossException.class);
     }
     try {
       appendFuture3.get();
       fail("Should fail with exception future3");
-    } catch (java.util.concurrent.ExecutionException e) {
-      assertEquals("Request aborted due to previous failures", e.getCause().getMessage());
+    } catch (ExecutionException e) {
+      assertThat(e.getCause()).isInstanceOf(AbortedException.class);
     }
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -954,7 +954,7 @@ public class StreamWriterTest {
     try {
       appendFuture2.get();
       fail("Should fail with exception future2");
-    } catch (java.util.concurrent.ExecutionException e) {
+    } catch (ExecutionException e) {
       assertThat(e.getCause()).isInstanceOf(DataLossException.class);
     }
     try {


### PR DESCRIPTION
Since there is major refactoring needed in order for this to work smoothly, temporarily remove this feature and let client retry connection. Also remove a flaky test FlushAllFailed, that feature is going to be removed in another PR.