### PR TITLE
chore: update api-bigquerystorage team access from admin to push

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -46,6 +46,6 @@ permissionRules:
 - team: yoshi-java-admins
   permission: admin
 - team: api-bigquerystorage
-  permission: admin
+  permission: push
 - team: yoshi-java
   permission: push


### PR DESCRIPTION
This gives api-bigquerystorage team members `write` access to the repo.