### PR TITLE
fix: add schema update back to json writer

### DIFF
--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -28,4 +28,19 @@
         <differenceType>7002</differenceType>
         <method>void flushAll(long)</method>
     </difference>
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamStreamWriter$Builder</className>
+        <differenceType>7002</differenceType>
+        <method>com.google.cloud.bigquery.storage.v1beta2.JsonStreamWriter$Builder setBatchingSettings(com.google.api.gax.batching.BatchingSettings)</method>
+    </difference>
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter$Builder</className>
+        <differenceType>7002</differenceType>
+        <method>com.google.cloud.bigquery.storage.v1beta2.JsonStreamWriter$Builder setExecutorProvider(com.google.api.gax.core.ExecutorProvider)</method>
+    </difference>
+    <difference>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter$Builder</className>
+        <differenceType>7002</differenceType>
+        <method>com.google.cloud.bigquery.storage.v1beta2.JsonStreamWriter$Builder setRetrySettings(com.google.api.gax.retrying.RetrySettings)</method>
+    </difference>
 </differences>

--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -29,7 +29,7 @@
         <method>void flushAll(long)</method>
     </difference>
     <difference>
-        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamStreamWriter$Builder</className>
+        <className>com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter$Builder</className>
         <differenceType>7002</differenceType>
         <method>com.google.cloud.bigquery.storage.v1beta2.JsonStreamWriter$Builder setBatchingSettings(com.google.api.gax.batching.BatchingSettings)</method>
     </difference>

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
@@ -17,9 +17,8 @@ package com.google.cloud.bigquery.storage.v1beta2;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.api.gax.core.ExecutorProvider;
-import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.bigquery.Schema;
 import com.google.common.base.Preconditions;
@@ -51,6 +50,7 @@ public class JsonStreamWriter implements AutoCloseable {
   private BigQueryWriteClient client;
   private String streamName;
   private StreamWriter streamWriter;
+  private StreamWriter.Builder streamWriterBuilder;
   private Descriptor descriptor;
   private TableSchema tableSchema;
 
@@ -66,20 +66,16 @@ public class JsonStreamWriter implements AutoCloseable {
     this.descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(builder.tableSchema);
 
-    StreamWriter.Builder streamWriterBuilder;
     if (this.client == null) {
       streamWriterBuilder = StreamWriter.newBuilder(builder.streamOrTableName);
     } else {
       streamWriterBuilder = StreamWriter.newBuilder(builder.streamOrTableName, builder.client);
     }
     setStreamWriterSettings(
-        streamWriterBuilder,
         builder.channelProvider,
         builder.credentialsProvider,
-        builder.batchingSettings,
-        builder.retrySettings,
-        builder.executorProvider,
         builder.endpoint,
+        builder.flowControlSettings,
         builder.createDefaultStream);
     this.streamWriter = streamWriterBuilder.build();
     this.streamName = this.streamWriter.getStreamNameString();
@@ -134,17 +130,17 @@ public class JsonStreamWriter implements AutoCloseable {
   }
 
   /**
-   * Refreshes connection for a JsonStreamWriter by first flushing all remaining rows, then calling
-   * refreshAppend(), and finally setting the descriptor. All of these actions need to be performed
-   * atomically to avoid having synchronization issues with append(). Flushing all rows first is
-   * necessary since if there are rows remaining when the connection refreshes, it will send out the
-   * old writer schema instead of the new one.
+   * Refreshes connection for a JsonStreamWriter by first flushing all remaining rows, then
+   * recreates stream writer, and finally setting the descriptor. All of these actions need to be
+   * performed atomically to avoid having synchronization issues with append(). Flushing all rows
+   * first is necessary since if there are rows remaining when the connection refreshes, it will
+   * send out the old writer schema instead of the new one.
    */
   void refreshConnection()
       throws IOException, InterruptedException, Descriptors.DescriptorValidationException {
     synchronized (this) {
-      this.streamWriter.writeAllOutstanding();
-      this.streamWriter.refreshAppend();
+      this.streamWriter.shutdown();
+      this.streamWriter = streamWriterBuilder.build();
       this.descriptor =
           BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(this.tableSchema);
     }
@@ -170,39 +166,33 @@ public class JsonStreamWriter implements AutoCloseable {
 
   /** Sets all StreamWriter settings. */
   private void setStreamWriterSettings(
-      StreamWriter.Builder builder,
       @Nullable TransportChannelProvider channelProvider,
       @Nullable CredentialsProvider credentialsProvider,
-      @Nullable BatchingSettings batchingSettings,
-      @Nullable RetrySettings retrySettings,
-      @Nullable ExecutorProvider executorProvider,
       @Nullable String endpoint,
+      @Nullable FlowControlSettings flowControlSettings,
       Boolean createDefaultStream) {
     if (channelProvider != null) {
-      builder.setChannelProvider(channelProvider);
+      streamWriterBuilder.setChannelProvider(channelProvider);
     }
     if (credentialsProvider != null) {
-      builder.setCredentialsProvider(credentialsProvider);
+      streamWriterBuilder.setCredentialsProvider(credentialsProvider);
     }
-    if (batchingSettings != null) {
-      builder.setBatchingSettings(batchingSettings);
-    }
-    if (retrySettings != null) {
-      builder.setRetrySettings(retrySettings);
-    }
-    if (executorProvider != null) {
-      builder.setExecutorProvider(executorProvider);
+    BatchingSettings.Builder batchSettingBuilder =
+        BatchingSettings.newBuilder().setElementCountThreshold(1L);
+    if (flowControlSettings != null) {
+      streamWriterBuilder.setBatchingSettings(
+          batchSettingBuilder.setFlowControlSettings(flowControlSettings).build());
     }
     if (endpoint != null) {
-      builder.setEndpoint(endpoint);
+      streamWriterBuilder.setEndpoint(endpoint);
     }
     if (createDefaultStream) {
-      builder.createDefaultStream();
+      streamWriterBuilder.createDefaultStream();
     }
     JsonStreamWriterOnSchemaUpdateRunnable jsonStreamWriterOnSchemaUpdateRunnable =
         new JsonStreamWriterOnSchemaUpdateRunnable();
     jsonStreamWriterOnSchemaUpdateRunnable.setJsonStreamWriter(this);
-    builder.setOnSchemaUpdateRunnable(jsonStreamWriterOnSchemaUpdateRunnable);
+    streamWriterBuilder.setOnSchemaUpdateRunnable(jsonStreamWriterOnSchemaUpdateRunnable);
   }
 
   /**
@@ -313,9 +303,7 @@ public class JsonStreamWriter implements AutoCloseable {
 
     private TransportChannelProvider channelProvider;
     private CredentialsProvider credentialsProvider;
-    private BatchingSettings batchingSettings;
-    private RetrySettings retrySettings;
-    private ExecutorProvider executorProvider;
+    private FlowControlSettings flowControlSettings;
     private String endpoint;
     private boolean createDefaultStream = false;
 
@@ -359,37 +347,15 @@ public class JsonStreamWriter implements AutoCloseable {
     }
 
     /**
-     * Setter for the underlying StreamWriter's BatchingSettings.
+     * Setter for the underlying StreamWriter's FlowControlSettings.
      *
-     * @param batchingSettings
+     * @param flowControlSettings
      * @return Builder
      */
-    public Builder setBatchingSettings(BatchingSettings batchingSettings) {
-      this.batchingSettings =
-          Preconditions.checkNotNull(batchingSettings, "BatchingSettings is null.");
-      return this;
-    }
-
-    /**
-     * Setter for the underlying StreamWriter's RetrySettings.
-     *
-     * @param retrySettings
-     * @return Builder
-     */
-    public Builder setRetrySettings(RetrySettings retrySettings) {
-      this.retrySettings = Preconditions.checkNotNull(retrySettings, "RetrySettings is null.");
-      return this;
-    }
-
-    /**
-     * Setter for the underlying StreamWriter's ExecutorProvider.
-     *
-     * @param executorProvider
-     * @return Builder
-     */
-    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
-      this.executorProvider =
-          Preconditions.checkNotNull(executorProvider, "ExecutorProvider is null.");
+    public Builder setFlowControlSettings(FlowControlSettings flowControlSettings) {
+      Preconditions.checkNotNull(flowControlSettings, "FlowControlSettings is null.");
+      this.flowControlSettings =
+          Preconditions.checkNotNull(flowControlSettings, "FlowControlSettings is null.");
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
@@ -178,10 +178,14 @@ public class JsonStreamWriter implements AutoCloseable {
       streamWriterBuilder.setCredentialsProvider(credentialsProvider);
     }
     BatchingSettings.Builder batchSettingBuilder =
-        BatchingSettings.newBuilder().setElementCountThreshold(1L);
+        BatchingSettings.newBuilder()
+            .setElementCountThreshold(1L)
+            .setRequestByteThreshold(4 * 1024 * 1024L);
     if (flowControlSettings != null) {
       streamWriterBuilder.setBatchingSettings(
           batchSettingBuilder.setFlowControlSettings(flowControlSettings).build());
+    } else {
+      streamWriterBuilder.setBatchingSettings(batchSettingBuilder.build());
     }
     if (endpoint != null) {
       streamWriterBuilder.setEndpoint(endpoint);

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -265,7 +265,9 @@ public class StreamWriter implements AutoCloseable {
       List<InflightBatch> batchesToSend;
       batchesToSend = messagesBatch.add(outstandingAppend);
       // Setup the next duration based delivery alarm if there are messages batched.
-      setupAlarm();
+      if (batchingSettings.getDelayThreshold() != null) {
+        setupAlarm();
+      }
       if (!batchesToSend.isEmpty()) {
         for (final InflightBatch batch : batchesToSend) {
           LOG.fine("Scheduling a batch for immediate sending");
@@ -738,55 +740,31 @@ public class StreamWriter implements AutoCloseable {
       if (batchingSettings.getRequestByteThreshold() > getApiMaxRequestBytes()) {
         builder.setRequestByteThreshold(getApiMaxRequestBytes());
       }
-      Preconditions.checkNotNull(batchingSettings.getDelayThreshold());
-      Preconditions.checkArgument(batchingSettings.getDelayThreshold().toMillis() > 0);
+      LOG.info("here" + batchingSettings.getFlowControlSettings());
       if (batchingSettings.getFlowControlSettings() == null) {
         builder.setFlowControlSettings(DEFAULT_FLOW_CONTROL_SETTINGS);
       } else {
-        if (batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount() == null) {
-          builder.setFlowControlSettings(
-              batchingSettings
-                  .getFlowControlSettings()
-                  .toBuilder()
-                  .setMaxOutstandingElementCount(
-                      DEFAULT_FLOW_CONTROL_SETTINGS.getMaxOutstandingElementCount())
-                  .build());
-        } else {
-          Preconditions.checkArgument(
-              batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount() > 0);
-          if (batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount()
-              > getApiMaxInflightRequests()) {
-            builder.setFlowControlSettings(
-                batchingSettings
-                    .getFlowControlSettings()
-                    .toBuilder()
-                    .setMaxOutstandingElementCount(getApiMaxInflightRequests())
-                    .build());
-          }
+        Long elementCount =
+            batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount();
+        if (elementCount == null || elementCount > getApiMaxInflightRequests()) {
+          elementCount = DEFAULT_FLOW_CONTROL_SETTINGS.getMaxOutstandingElementCount();
         }
-        if (batchingSettings.getFlowControlSettings().getMaxOutstandingRequestBytes() == null) {
-          builder.setFlowControlSettings(
-              batchingSettings
-                  .getFlowControlSettings()
-                  .toBuilder()
-                  .setMaxOutstandingRequestBytes(
-                      DEFAULT_FLOW_CONTROL_SETTINGS.getMaxOutstandingRequestBytes())
-                  .build());
-        } else {
-          Preconditions.checkArgument(
-              batchingSettings.getFlowControlSettings().getMaxOutstandingRequestBytes() > 0);
+        Long elementSize =
+            batchingSettings.getFlowControlSettings().getMaxOutstandingRequestBytes();
+        if (elementSize == null || elementSize < 0) {
+          elementSize = DEFAULT_FLOW_CONTROL_SETTINGS.getMaxOutstandingRequestBytes();
         }
-        if (batchingSettings.getFlowControlSettings().getLimitExceededBehavior() == null
-            || batchingSettings.getFlowControlSettings().getLimitExceededBehavior()
-                == FlowController.LimitExceededBehavior.Ignore) {
-          builder.setFlowControlSettings(
-              batchingSettings
-                  .getFlowControlSettings()
-                  .toBuilder()
-                  .setLimitExceededBehavior(
-                      DEFAULT_FLOW_CONTROL_SETTINGS.getLimitExceededBehavior())
-                  .build());
+        FlowController.LimitExceededBehavior behavior =
+            batchingSettings.getFlowControlSettings().getLimitExceededBehavior();
+        if (behavior == null || behavior == FlowController.LimitExceededBehavior.Ignore) {
+          behavior = DEFAULT_FLOW_CONTROL_SETTINGS.getLimitExceededBehavior();
         }
+        builder.setFlowControlSettings(
+            FlowControlSettings.newBuilder()
+                .setMaxOutstandingElementCount(elementCount)
+                .setMaxOutstandingRequestBytes(elementSize)
+                .setLimitExceededBehavior(behavior)
+                .build());
       }
       this.batchingSettings = builder.build();
       return this;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriter.java
@@ -743,7 +743,6 @@ public class StreamWriter implements AutoCloseable {
       if (batchingSettings.getFlowControlSettings() == null) {
         builder.setFlowControlSettings(DEFAULT_FLOW_CONTROL_SETTINGS);
       } else {
-
         if (batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount() == null) {
           builder.setFlowControlSettings(
               batchingSettings
@@ -777,7 +776,9 @@ public class StreamWriter implements AutoCloseable {
           Preconditions.checkArgument(
               batchingSettings.getFlowControlSettings().getMaxOutstandingRequestBytes() > 0);
         }
-        if (batchingSettings.getFlowControlSettings().getLimitExceededBehavior() == null) {
+        if (batchingSettings.getFlowControlSettings().getLimitExceededBehavior() == null
+            || batchingSettings.getFlowControlSettings().getLimitExceededBehavior()
+                == FlowController.LimitExceededBehavior.Ignore) {
           builder.setFlowControlSettings(
               batchingSettings
                   .getFlowControlSettings()
@@ -785,10 +786,6 @@ public class StreamWriter implements AutoCloseable {
                   .setLimitExceededBehavior(
                       DEFAULT_FLOW_CONTROL_SETTINGS.getLimitExceededBehavior())
                   .build());
-        } else {
-          Preconditions.checkArgument(
-              batchingSettings.getFlowControlSettings().getLimitExceededBehavior()
-                  != FlowController.LimitExceededBehavior.Ignore);
         }
       }
       this.batchingSettings = builder.build();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriterTest.java
@@ -711,6 +711,11 @@ public class JsonStreamWriterTest {
               .setAppendResult(
                   AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(2)).build())
               .build());
+      testBigQueryWrite.addResponse(
+          AppendRowsResponse.newBuilder()
+              .setAppendResult(
+                  AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(3)).build())
+              .build());
       // First append
       JSONObject foo = new JSONObject();
       foo.put("foo", "allen");
@@ -778,18 +783,19 @@ public class JsonStreamWriterTest {
       ApiFuture<AppendRowsResponse> appendFuture4 = writer.append(updatedJsonArr);
 
       assertEquals(3L, appendFuture4.get().getAppendResult().getOffset().getValue());
+      assertEquals(4, testBigQueryWrite.getAppendRequests().size());
       assertEquals(
           1,
           testBigQueryWrite
               .getAppendRequests()
-              .get(2)
+              .get(3)
               .getProtoRows()
               .getRows()
               .getSerializedRowsCount());
       assertEquals(
           testBigQueryWrite
               .getAppendRequests()
-              .get(2)
+              .get(3)
               .getProtoRows()
               .getRows()
               .getSerializedRows(0),
@@ -797,8 +803,8 @@ public class JsonStreamWriterTest {
 
       assertTrue(testBigQueryWrite.getAppendRequests().get(0).getProtoRows().hasWriterSchema());
       assertTrue(
-          testBigQueryWrite.getAppendRequests().get(1).getProtoRows().hasWriterSchema()
-              || testBigQueryWrite.getAppendRequests().get(2).getProtoRows().hasWriterSchema());
+          testBigQueryWrite.getAppendRequests().get(2).getProtoRows().hasWriterSchema()
+              || testBigQueryWrite.getAppendRequests().get(3).getProtoRows().hasWriterSchema());
     }
   }
 
@@ -850,7 +856,6 @@ public class JsonStreamWriterTest {
                       AppendRowsResponse response = appendFuture.get();
                       offsetSets.remove(response.getAppendResult().getOffset().getValue());
                     } catch (Exception e) {
-
                       LOG.severe("Thread execution failed: " + e.getMessage());
                     }
                   }
@@ -864,6 +869,7 @@ public class JsonStreamWriterTest {
       }
       assertTrue(offsetSets.size() == 0);
       for (int i = 0; i < thread_nums; i++) {
+        LOG.info(testBigQueryWrite.getAppendRequests().get(i).toString());
         assertEquals(
             1,
             testBigQueryWrite

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriterTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.storage.test.JsonTest.ComplexRoot;
 import com.google.cloud.bigquery.storage.test.Test.FooType;
+import com.google.cloud.bigquery.storage.test.Test.UpdatedFooType;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Int64Value;
@@ -205,7 +206,6 @@ public class JsonStreamWriterTest {
       String testStream, TableSchema BQTableSchema) {
     return JsonStreamWriter.newBuilder(testStream, BQTableSchema)
         .setChannelProvider(channelProvider)
-        .setExecutorProvider(SINGLE_THREAD_EXECUTOR)
         .setCredentialsProvider(NoCredentialsProvider.create());
   }
 
@@ -623,202 +623,184 @@ public class JsonStreamWriterTest {
     }
   }
 
-  //  @Test
-  //  public void testAppendOutOfRangeAndUpdateSchema() throws Exception {
-  //    try (JsonStreamWriter writer =
-  //        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {
-  //      testBigQueryWrite.addResponse(
-  //          AppendRowsResponse.newBuilder()
-  //              .setError(com.google.rpc.Status.newBuilder().setCode(11).build())
-  //              .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
-  //              .build());
-  //      testBigQueryWrite.addResponse(
-  //          AppendRowsResponse.newBuilder()
-  //              .setAppendResult(
-  //
-  // AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
-  //              .build());
-  //
-  //      JSONObject foo = new JSONObject();
-  //      foo.put("foo", "allen");
-  //      JSONArray jsonArr = new JSONArray();
-  //      jsonArr.put(foo);
-  //      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
-  //      try {
-  //        appendFuture.get();
-  //        Assert.fail("expected ExecutionException");
-  //      } catch (ExecutionException ex) {
-  //        assertEquals(ex.getCause().getMessage(), "OUT_OF_RANGE: ");
-  //        int millis = 0;
-  //        while (millis <= 10000) {
-  //          if (writer.getDescriptor().getFields().size() == 2) {
-  //            break;
-  //          }
-  //          Thread.sleep(100);
-  //          millis += 100;
-  //        }
-  //        assertTrue(writer.getDescriptor().getFields().size() == 2);
-  //      }
-  //
-  //      JSONObject updatedFoo = new JSONObject();
-  //      updatedFoo.put("foo", "allen");
-  //      updatedFoo.put("bar", "allen2");
-  //      JSONArray updatedJsonArr = new JSONArray();
-  //      updatedJsonArr.put(updatedFoo);
-  //
-  //      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(updatedJsonArr);
-  //      assertEquals(0L, appendFuture2.get().getAppendResult().getOffset().getValue());
-  //      appendFuture2.get();
-  //      assertEquals(
-  //          1,
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(1)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRowsCount());
-  //      assertEquals(
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(1)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRows(0),
-  //          UpdatedFooType.newBuilder().setFoo("allen").setBar("allen2").build().toByteString());
-  //
-  //      // Check if writer schemas were added in for both connections.
-  //      assertTrue(testBigQueryWrite.getAppendRequests().get(0).getProtoRows().hasWriterSchema());
-  //      assertTrue(testBigQueryWrite.getAppendRequests().get(1).getProtoRows().hasWriterSchema());
-  //    }
-  //  }
+  @Test
+  public void testAppendOutOfRangeAndUpdateSchema() throws Exception {
+    try (JsonStreamWriter writer =
+        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {
+      testBigQueryWrite.addResponse(
+          AppendRowsResponse.newBuilder()
+              .setError(com.google.rpc.Status.newBuilder().setCode(11).build())
+              .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
+              .build());
+      testBigQueryWrite.addResponse(
+          AppendRowsResponse.newBuilder()
+              .setAppendResult(
+                  AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
+              .build());
 
-  //  @Test
-  //  public void testSchemaUpdateWithNonemptyBatch() throws Exception {
-  //    try (JsonStreamWriter writer =
-  //        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA)
-  //            .setBatchingSettings(
-  //                StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
-  //                    .toBuilder()
-  //                    .setElementCountThreshold(2L)
-  //                    .build())
-  //            .build()) {
-  //      testBigQueryWrite.addResponse(
-  //          AppendRowsResponse.newBuilder()
-  //              .setAppendResult(
-  //
-  // AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
-  //              .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
-  //              .build());
-  //      testBigQueryWrite.addResponse(
-  //          AppendRowsResponse.newBuilder()
-  //              .setAppendResult(
-  //
-  // AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(2)).build())
-  //              .build());
-  //      testBigQueryWrite.addResponse(
-  //          AppendRowsResponse.newBuilder()
-  //              .setAppendResult(
-  //
-  // AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(3)).build())
-  //              .build());
-  //      // First append
-  //      JSONObject foo = new JSONObject();
-  //      foo.put("foo", "allen");
-  //      JSONArray jsonArr = new JSONArray();
-  //      jsonArr.put(foo);
-  //
-  //      ApiFuture<AppendRowsResponse> appendFuture1 = writer.append(jsonArr);
-  //      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(jsonArr);
-  //      ApiFuture<AppendRowsResponse> appendFuture3 = writer.append(jsonArr);
-  //
-  //      assertEquals(0L, appendFuture1.get().getAppendResult().getOffset().getValue());
-  //      assertEquals(1L, appendFuture2.get().getAppendResult().getOffset().getValue());
-  //      assertEquals(
-  //          2,
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(0)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRowsCount());
-  //      assertEquals(
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(0)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRows(0),
-  //          FooType.newBuilder().setFoo("allen").build().toByteString());
-  //      assertEquals(
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(0)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRows(1),
-  //          FooType.newBuilder().setFoo("allen").build().toByteString());
-  //
-  //      assertEquals(2L, appendFuture3.get().getAppendResult().getOffset().getValue());
-  //      assertEquals(
-  //          1,
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(1)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRowsCount());
-  //      assertEquals(
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(1)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRows(0),
-  //          FooType.newBuilder().setFoo("allen").build().toByteString());
-  //
-  //      int millis = 0;
-  //      while (millis <= 10000) {
-  //        if (writer.getDescriptor().getFields().size() == 2) {
-  //          break;
-  //        }
-  //        Thread.sleep(100);
-  //        millis += 100;
-  //      }
-  //      assertTrue(writer.getDescriptor().getFields().size() == 2);
-  //
-  //      // Second append with updated schema.
-  //      JSONObject updatedFoo = new JSONObject();
-  //      updatedFoo.put("foo", "allen");
-  //      updatedFoo.put("bar", "allen2");
-  //      JSONArray updatedJsonArr = new JSONArray();
-  //      updatedJsonArr.put(updatedFoo);
-  //
-  //      ApiFuture<AppendRowsResponse> appendFuture4 = writer.append(updatedJsonArr);
-  //
-  //      assertEquals(3L, appendFuture4.get().getAppendResult().getOffset().getValue());
-  //      assertEquals(
-  //          1,
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(2)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRowsCount());
-  //      assertEquals(
-  //          testBigQueryWrite
-  //              .getAppendRequests()
-  //              .get(2)
-  //              .getProtoRows()
-  //              .getRows()
-  //              .getSerializedRows(0),
-  //          UpdatedFooType.newBuilder().setFoo("allen").setBar("allen2").build().toByteString());
-  //
-  //      assertTrue(testBigQueryWrite.getAppendRequests().get(0).getProtoRows().hasWriterSchema());
-  //      assertTrue(
-  //          testBigQueryWrite.getAppendRequests().get(1).getProtoRows().hasWriterSchema()
-  //              || testBigQueryWrite.getAppendRequests().get(2).getProtoRows().hasWriterSchema());
-  //    }
-  //  }
+      JSONObject foo = new JSONObject();
+      foo.put("foo", "allen");
+      JSONArray jsonArr = new JSONArray();
+      jsonArr.put(foo);
+      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
+      try {
+        appendFuture.get();
+        Assert.fail("expected ExecutionException");
+      } catch (ExecutionException ex) {
+        assertEquals(ex.getCause().getMessage(), "OUT_OF_RANGE: ");
+        int millis = 0;
+        while (millis <= 10000) {
+          if (writer.getDescriptor().getFields().size() == 2) {
+            break;
+          }
+          Thread.sleep(100);
+          millis += 100;
+        }
+        assertTrue(writer.getDescriptor().getFields().size() == 2);
+      }
+
+      JSONObject updatedFoo = new JSONObject();
+      updatedFoo.put("foo", "allen");
+      updatedFoo.put("bar", "allen2");
+      JSONArray updatedJsonArr = new JSONArray();
+      updatedJsonArr.put(updatedFoo);
+
+      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(updatedJsonArr);
+      assertEquals(0L, appendFuture2.get().getAppendResult().getOffset().getValue());
+      appendFuture2.get();
+      assertEquals(
+          1,
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(1)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRowsCount());
+      assertEquals(
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(1)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRows(0),
+          UpdatedFooType.newBuilder().setFoo("allen").setBar("allen2").build().toByteString());
+
+      // Check if writer schemas were added in for both connections.
+      assertTrue(testBigQueryWrite.getAppendRequests().get(0).getProtoRows().hasWriterSchema());
+      assertTrue(testBigQueryWrite.getAppendRequests().get(1).getProtoRows().hasWriterSchema());
+    }
+  }
+
+  @Test
+  public void testSchemaUpdateSuccess() throws Exception {
+    try (JsonStreamWriter writer =
+        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {
+      testBigQueryWrite.addResponse(
+          AppendRowsResponse.newBuilder()
+              .setAppendResult(
+                  AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
+              .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
+              .build());
+      testBigQueryWrite.addResponse(
+          AppendRowsResponse.newBuilder()
+              .setAppendResult(
+                  AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(1)).build())
+              .build());
+      testBigQueryWrite.addResponse(
+          AppendRowsResponse.newBuilder()
+              .setAppendResult(
+                  AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(2)).build())
+              .build());
+      // First append
+      JSONObject foo = new JSONObject();
+      foo.put("foo", "allen");
+      JSONArray jsonArr = new JSONArray();
+      jsonArr.put(foo);
+
+      ApiFuture<AppendRowsResponse> appendFuture1 = writer.append(jsonArr);
+      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(jsonArr);
+      ApiFuture<AppendRowsResponse> appendFuture3 = writer.append(jsonArr);
+
+      assertEquals(0L, appendFuture1.get().getAppendResult().getOffset().getValue());
+      assertEquals(1L, appendFuture2.get().getAppendResult().getOffset().getValue());
+      assertEquals(
+          1,
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(0)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRowsCount());
+      assertEquals(
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(0)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRows(0),
+          FooType.newBuilder().setFoo("allen").build().toByteString());
+
+      assertEquals(2L, appendFuture3.get().getAppendResult().getOffset().getValue());
+      assertEquals(
+          1,
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(1)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRowsCount());
+      assertEquals(
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(1)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRows(0),
+          FooType.newBuilder().setFoo("allen").build().toByteString());
+
+      int millis = 0;
+      while (millis <= 10000) {
+        if (writer.getDescriptor().getFields().size() == 2) {
+          break;
+        }
+        Thread.sleep(100);
+        millis += 100;
+      }
+      assertTrue(writer.getDescriptor().getFields().size() == 2);
+
+      // Second append with updated schema.
+      JSONObject updatedFoo = new JSONObject();
+      updatedFoo.put("foo", "allen");
+      updatedFoo.put("bar", "allen2");
+      JSONArray updatedJsonArr = new JSONArray();
+      updatedJsonArr.put(updatedFoo);
+
+      ApiFuture<AppendRowsResponse> appendFuture4 = writer.append(updatedJsonArr);
+
+      assertEquals(3L, appendFuture4.get().getAppendResult().getOffset().getValue());
+      assertEquals(
+          1,
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(2)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRowsCount());
+      assertEquals(
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(2)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRows(0),
+          UpdatedFooType.newBuilder().setFoo("allen").setBar("allen2").build().toByteString());
+
+      assertTrue(testBigQueryWrite.getAppendRequests().get(0).getProtoRows().hasWriterSchema());
+      assertTrue(
+          testBigQueryWrite.getAppendRequests().get(1).getProtoRows().hasWriterSchema()
+              || testBigQueryWrite.getAppendRequests().get(2).getProtoRows().hasWriterSchema());
+    }
+  }
 
   @Test
   public void testCreateDefaultStream() throws Exception {
@@ -831,7 +813,6 @@ public class JsonStreamWriterTest {
         JsonStreamWriter.newBuilder(TEST_TABLE, v2Schema)
             .createDefaultStream()
             .setChannelProvider(channelProvider)
-            .setExecutorProvider(SINGLE_THREAD_EXECUTOR)
             .setCredentialsProvider(NoCredentialsProvider.create())
             .build()) {
       assertEquals("projects/p/datasets/d/tables/t/_default", writer.getStreamName());
@@ -841,13 +822,7 @@ public class JsonStreamWriterTest {
   @Test
   public void testMultiThreadAppendNoSchemaUpdate() throws Exception {
     try (JsonStreamWriter writer =
-        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA)
-            .setBatchingSettings(
-                StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
-                    .toBuilder()
-                    .setElementCountThreshold(1L)
-                    .build())
-            .build()) {
+        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {
 
       JSONObject foo = new JSONObject();
       foo.put("foo", "allen");
@@ -909,149 +884,141 @@ public class JsonStreamWriterTest {
     }
   }
 
-  //  @Test
-  //  public void testMultiThreadAppendWithSchemaUpdate() throws Exception {
-  //    try (JsonStreamWriter writer =
-  //        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA)
-  //            .setBatchingSettings(
-  //                StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
-  //                    .toBuilder()
-  //                    .setElementCountThreshold(1L)
-  //                    .build())
-  //            .build()) {
-  //      JSONObject foo = new JSONObject();
-  //      foo.put("foo", "allen");
-  //      final JSONArray jsonArr = new JSONArray();
-  //      jsonArr.put(foo);
-  //
-  //      final Collection<Long> offsetSets = Collections.synchronizedCollection(new
-  // HashSet<Long>());
-  //      int numberThreads = 5;
-  //      Thread[] thread_arr = new Thread[numberThreads];
-  //      for (int i = 0; i < numberThreads; i++) {
-  //        if (i == 2) {
-  //          testBigQueryWrite.addResponse(
-  //              AppendRowsResponse.newBuilder()
-  //                  .setAppendResult(
-  //                      AppendRowsResponse.AppendResult.newBuilder()
-  //                          .setOffset(Int64Value.of(i))
-  //                          .build())
-  //                  .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
-  //                  .build());
-  //        } else {
-  //          testBigQueryWrite.addResponse(
-  //              AppendRowsResponse.newBuilder()
-  //                  .setAppendResult(
-  //                      AppendRowsResponse.AppendResult.newBuilder()
-  //                          .setOffset(Int64Value.of(i))
-  //                          .build())
-  //                  .build());
-  //        }
-  //
-  //        offsetSets.add((long) i);
-  //        Thread t =
-  //            new Thread(
-  //                new Runnable() {
-  //                  public void run() {
-  //                    try {
-  //                      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
-  //                      AppendRowsResponse response = appendFuture.get();
-  //                      offsetSets.remove(response.getAppendResult().getOffset().getValue());
-  //                    } catch (Exception e) {
-  //                      LOG.severe("Thread execution failed: " + e.getMessage());
-  //                    }
-  //                  }
-  //                });
-  //        thread_arr[i] = t;
-  //        t.start();
-  //      }
-  //
-  //      for (int i = 0; i < numberThreads; i++) {
-  //        thread_arr[i].join();
-  //      }
-  //      assertTrue(offsetSets.size() == 0);
-  //      for (int i = 0; i < numberThreads; i++) {
-  //        assertEquals(
-  //            1,
-  //            testBigQueryWrite
-  //                .getAppendRequests()
-  //                .get(i)
-  //                .getProtoRows()
-  //                .getRows()
-  //                .getSerializedRowsCount());
-  //        assertEquals(
-  //            testBigQueryWrite
-  //                .getAppendRequests()
-  //                .get(i)
-  //                .getProtoRows()
-  //                .getRows()
-  //                .getSerializedRows(0),
-  //            FooType.newBuilder().setFoo("allen").build().toByteString());
-  //      }
-  //
-  //      int millis = 0;
-  //      while (millis <= 10000) {
-  //        if (writer.getDescriptor().getFields().size() == 2) {
-  //          break;
-  //        }
-  //        Thread.sleep(100);
-  //        millis += 100;
-  //      }
-  //      assertEquals(2, writer.getDescriptor().getFields().size());
-  //
-  //      foo.put("bar", "allen2");
-  //      final JSONArray jsonArr2 = new JSONArray();
-  //      jsonArr2.put(foo);
-  //
-  //      for (int i = numberThreads; i < numberThreads + 5; i++) {
-  //        testBigQueryWrite.addResponse(
-  //            AppendRowsResponse.newBuilder()
-  //                .setAppendResult(
-  //                    AppendRowsResponse.AppendResult.newBuilder()
-  //                        .setOffset(Int64Value.of(i))
-  //                        .build())
-  //                .build());
-  //        offsetSets.add((long) i);
-  //        Thread t =
-  //            new Thread(
-  //                new Runnable() {
-  //                  public void run() {
-  //                    try {
-  //                      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr2);
-  //                      AppendRowsResponse response = appendFuture.get();
-  //                      offsetSets.remove(response.getAppendResult().getOffset().getValue());
-  //                    } catch (Exception e) {
-  //                      LOG.severe("Thread execution failed: " + e.getMessage());
-  //                    }
-  //                  }
-  //                });
-  //        thread_arr[i - 5] = t;
-  //        t.start();
-  //      }
-  //
-  //      for (int i = 0; i < numberThreads; i++) {
-  //        thread_arr[i].join();
-  //      }
-  //      assertTrue(offsetSets.size() == 0);
-  //      for (int i = 0; i < numberThreads; i++) {
-  //        assertEquals(
-  //            1,
-  //            testBigQueryWrite
-  //                .getAppendRequests()
-  //                .get(i + 5)
-  //                .getProtoRows()
-  //                .getRows()
-  //                .getSerializedRowsCount());
-  //        assertEquals(
-  //            testBigQueryWrite
-  //                .getAppendRequests()
-  //                .get(i + 5)
-  //                .getProtoRows()
-  //                .getRows()
-  //                .getSerializedRows(0),
-  //
-  // UpdatedFooType.newBuilder().setFoo("allen").setBar("allen2").build().toByteString());
-  //      }
-  //    }
-  //  }
+  @Test
+  public void testMultiThreadAppendWithSchemaUpdate() throws Exception {
+    try (JsonStreamWriter writer =
+        getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {
+      JSONObject foo = new JSONObject();
+      foo.put("foo", "allen");
+      final JSONArray jsonArr = new JSONArray();
+      jsonArr.put(foo);
+
+      final Collection<Long> offsetSets = Collections.synchronizedCollection(new HashSet<Long>());
+      int numberThreads = 5;
+      Thread[] thread_arr = new Thread[numberThreads];
+      for (int i = 0; i < numberThreads; i++) {
+        if (i == 2) {
+          testBigQueryWrite.addResponse(
+              AppendRowsResponse.newBuilder()
+                  .setAppendResult(
+                      AppendRowsResponse.AppendResult.newBuilder()
+                          .setOffset(Int64Value.of(i))
+                          .build())
+                  .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
+                  .build());
+        } else {
+          testBigQueryWrite.addResponse(
+              AppendRowsResponse.newBuilder()
+                  .setAppendResult(
+                      AppendRowsResponse.AppendResult.newBuilder()
+                          .setOffset(Int64Value.of(i))
+                          .build())
+                  .build());
+        }
+
+        offsetSets.add((long) i);
+        Thread t =
+            new Thread(
+                new Runnable() {
+                  public void run() {
+                    try {
+                      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
+                      AppendRowsResponse response = appendFuture.get();
+                      offsetSets.remove(response.getAppendResult().getOffset().getValue());
+                    } catch (Exception e) {
+                      LOG.severe("Thread execution failed: " + e.getMessage());
+                    }
+                  }
+                });
+        thread_arr[i] = t;
+        t.start();
+      }
+
+      for (int i = 0; i < numberThreads; i++) {
+        thread_arr[i].join();
+      }
+      assertTrue(offsetSets.size() == 0);
+      for (int i = 0; i < numberThreads; i++) {
+        assertEquals(
+            1,
+            testBigQueryWrite
+                .getAppendRequests()
+                .get(i)
+                .getProtoRows()
+                .getRows()
+                .getSerializedRowsCount());
+        assertEquals(
+            testBigQueryWrite
+                .getAppendRequests()
+                .get(i)
+                .getProtoRows()
+                .getRows()
+                .getSerializedRows(0),
+            FooType.newBuilder().setFoo("allen").build().toByteString());
+      }
+
+      int millis = 0;
+      while (millis <= 10000) {
+        if (writer.getDescriptor().getFields().size() == 2) {
+          break;
+        }
+        Thread.sleep(100);
+        millis += 100;
+      }
+      assertEquals(2, writer.getDescriptor().getFields().size());
+
+      foo.put("bar", "allen2");
+      final JSONArray jsonArr2 = new JSONArray();
+      jsonArr2.put(foo);
+
+      for (int i = numberThreads; i < numberThreads + 5; i++) {
+        testBigQueryWrite.addResponse(
+            AppendRowsResponse.newBuilder()
+                .setAppendResult(
+                    AppendRowsResponse.AppendResult.newBuilder()
+                        .setOffset(Int64Value.of(i))
+                        .build())
+                .build());
+        offsetSets.add((long) i);
+        Thread t =
+            new Thread(
+                new Runnable() {
+                  public void run() {
+                    try {
+                      ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr2);
+                      AppendRowsResponse response = appendFuture.get();
+                      offsetSets.remove(response.getAppendResult().getOffset().getValue());
+                    } catch (Exception e) {
+                      LOG.severe("Thread execution failed: " + e.getMessage());
+                    }
+                  }
+                });
+        thread_arr[i - 5] = t;
+        t.start();
+      }
+
+      for (int i = 0; i < numberThreads; i++) {
+        thread_arr[i].join();
+      }
+      assertTrue(offsetSets.size() == 0);
+      for (int i = 0; i < numberThreads; i++) {
+        assertEquals(
+            1,
+            testBigQueryWrite
+                .getAppendRequests()
+                .get(i + 5)
+                .getProtoRows()
+                .getRows()
+                .getSerializedRowsCount());
+        assertEquals(
+            testBigQueryWrite
+                .getAppendRequests()
+                .get(i + 5)
+                .getProtoRows()
+                .getRows()
+                .getSerializedRows(0),
+            UpdatedFooType.newBuilder().setFoo("allen").setBar("allen2").build().toByteString());
+      }
+    }
+  }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -678,6 +678,7 @@ public class StreamWriterTest {
                     .toBuilder()
                     // When shutdown, we should have something in batch.
                     .setElementCountThreshold(3L)
+                    .setDelayThreshold(Duration.ofSeconds(1000))
                     .setFlowControlSettings(
                         StreamWriter.Builder.DEFAULT_FLOW_CONTROL_SETTINGS
                             .toBuilder()

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -1305,16 +1305,6 @@ public class StreamWriterTest {
       builder.setBatchingSettings(
           StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
               .toBuilder()
-              .setDelayThreshold(null)
-              .build());
-      fail("Should have thrown an NullPointerException");
-    } catch (NullPointerException expected) {
-      // Expected
-    }
-    try {
-      builder.setBatchingSettings(
-          StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
-              .toBuilder()
               .setDelayThreshold(Duration.ofMillis(-1))
               .build());
       fail("Should have thrown an IllegalArgumentException");
@@ -1383,8 +1373,7 @@ public class StreamWriterTest {
     } catch (IllegalArgumentException expected) {
       // Expected
     }
-
-    try {
+    {
       FlowControlSettings flowControlSettings =
           FlowControlSettings.newBuilder()
               .setLimitExceededBehavior(FlowController.LimitExceededBehavior.Ignore)
@@ -1394,11 +1383,7 @@ public class StreamWriterTest {
               .toBuilder()
               .setFlowControlSettings(flowControlSettings)
               .build());
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
-      // Expected
     }
-
     try {
       FlowControlSettings flowControlSettings =
           FlowControlSettings.newBuilder().setLimitExceededBehavior(null).build();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -698,7 +698,7 @@ public class StreamWriterTest {
           AppendRowsResponse.newBuilder()
               .setAppendResult(
                   AppendRowsResponse.AppendResult.newBuilder()
-                      .setOffset(Int64Value.of(i * 3))
+                      .setOffset(Int64Value.of(i * 3 + 2))
                       .build())
               .build());
     }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/StreamWriterTest.java
@@ -698,7 +698,7 @@ public class StreamWriterTest {
           AppendRowsResponse.newBuilder()
               .setAppendResult(
                   AppendRowsResponse.AppendResult.newBuilder()
-                      .setOffset(Int64Value.of(i * 3 + 2))
+                      .setOffset(Int64Value.of(i * 3))
                       .build())
               .build());
     }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryWriteManualClientTest.java
@@ -205,7 +205,7 @@ public class ITBigQueryWriteManualClientTest {
   }
 
   @Test
-  public void testJsonStreamWriterBatchWriteWithCommittedStream()
+  public void testJsonStreamWriterWriteWithCommittedStream()
       throws IOException, InterruptedException, ExecutionException,
           Descriptors.DescriptorValidationException {
     String tableName = "JsonTable";
@@ -235,15 +235,7 @@ public class ITBigQueryWriteManualClientTest {
                     WriteStream.newBuilder().setType(WriteStream.Type.COMMITTED).build())
                 .build());
     try (JsonStreamWriter jsonStreamWriter =
-        JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema())
-            .setBatchingSettings(
-                StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
-                    .toBuilder()
-                    .setRequestByteThreshold(1024 * 1024L) // 1 Mb
-                    .setElementCountThreshold(2L)
-                    .setDelayThreshold(Duration.ofSeconds(2))
-                    .build())
-            .build()) {
+        JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema()).build()) {
       LOG.info("Sending one message");
       JSONObject row1 = new JSONObject();
       row1.put("test_str", "aaa");
@@ -316,13 +308,6 @@ public class ITBigQueryWriteManualClientTest {
     try (JsonStreamWriter jsonStreamWriter =
         JsonStreamWriter.newBuilder(parent.toString(), tableInfo.getDefinition().getSchema())
             .createDefaultStream()
-            .setBatchingSettings(
-                StreamWriter.Builder.DEFAULT_BATCHING_SETTINGS
-                    .toBuilder()
-                    .setRequestByteThreshold(1024 * 1024L) // 1 Mb
-                    .setElementCountThreshold(2L)
-                    .setDelayThreshold(Duration.ofSeconds(2))
-                    .build())
             .build()) {
       LOG.info("Sending one message");
       JSONObject row1 = new JSONObject();


### PR DESCRIPTION
1. Add schema update back to json writer by recreate the stream.
2. Remove the batching support on json writer so that potentially it can be moved to use StreamWriterV2. This is to avoid users become dependent on the feature. Currently the move is not possible because StreamWriterV2 is lacking the schema update callback feature. It can probably be done inside json writer as well, but will do this later.
3. Also remove RetrySetting ExecutorSetting to be more consistent with what we actual support right now.
