### PR TITLE
chore: update protoc plugin to address build failure observed

### DIFF
--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -26,9 +26,9 @@
     </extensions>
     <plugins>
       <plugin>
-        <groupId>com.google.protobuf.tools</groupId>
-        <artifactId>maven-protoc-plugin</artifactId>
-        <version>0.4.2</version>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${project.protobuf-java.version}:exe:${os.detected.classifier}</protocArtifact>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,6 @@
       <name>Central Repository</name>
       <url>https://repo.maven.apache.org/maven2</url>
     </pluginRepository>
-    <pluginRepository>
-      <id>protoc-plugin</id>
-      <url>https://dl.bintray.com/sergei-ivanov/maven/</url>
-    </pluginRepository>
   </pluginRepositories>
 
   <dependencyManagement>


### PR DESCRIPTION
Build failure observed in https://github.com/googleapis/java-bigquerystorage/pull/1000/checks?check_run_id=2325305545 when [updating libraries-bom](https://github.com/googleapis/java-bigquerystorage/pull/999):

```
Error:  Plugin com.google.protobuf.tools:maven-protoc-plugin:0.4.2 or one of its dependencies could not be resolved: Failed to read artifact descriptor for com.google.protobuf.tools:maven-protoc-plugin:jar:0.4.2: Could not transfer artifact com.google.protobuf.tools:maven-protoc-plugin:pom:0.4.2 from/to protoc-plugin (https://dl.bintray.com/sergei-ivanov/maven/): Authorization failed for https://dl.bintray.com/sergei-ivanov/maven/com/google/protobuf/tools/maven-protoc-plugin/0.4.2/maven-protoc-plugin-0.4.2.pom 403 Forbidden -> [Help 1]
```