### PR TITLE
fix: More robust STREAM_RST logic

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.storage.util;
+
+import io.grpc.Status;
+
+/** Static utility methods for working with Errors returned from the service. */
+public class Errors {
+  private Errors() {};
+
+  /**
+   * Returns true iff the Status indicates and internal error that is retryable.
+   *
+   * <p>Generally, internal errors are not considered retryable, however there are certain transient
+   * network issues that appear as internal but are in fact retryable.
+   */
+  public static boolean isRetryableInternalStatus(Status status) {
+    String description = status.getDescription();
+    return status.getCode() == Status.Code.INTERNAL
+        && description != null
+        && (description.contains("Received unexpected EOS on DATA frame from server")
+            || description.contains(" Rst ")
+            || description.contains("RST_STREAM")
+            || description.contains("Connection closed with unknown cause")
+            || description.contains("HTTP/2 error code: INTERNAL_ERROR"));
+  }
+}

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/util/ErrorsTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/util/ErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/util/ErrorsTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/util/ErrorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.storage.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.grpc.Status;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ErrorsTest {
+
+  @Test
+  public void testRetryableInternalForRstErrors() {
+    assertTrue(
+        Errors.isRetryableInternalStatus(
+            Status.INTERNAL.withDescription(
+                "HTTP/2 error code: INTERNAL_ERROR\nReceived Rst stream")));
+    assertTrue(
+        Errors.isRetryableInternalStatus(
+            Status.INTERNAL.withDescription(
+                "RST_STREAM closed stream. HTTP/2 error code: INTERNAL_ERROR")));
+  }
+
+  @Test
+  public void testNonRetryableInternalError() {
+    assertFalse(Errors.isRetryableInternalStatus(Status.INTERNAL));
+    assertFalse(Errors.isRetryableInternalStatus(Status.INTERNAL.withDescription("Server error.")));
+  }
+
+  @Test
+  public void testNonRetryableOtherError() {
+    assertFalse(
+        Errors.isRetryableInternalStatus(
+            Status.DATA_LOSS.withDescription(
+                "RST_STREAM closed stream. HTTP/2 error code: INTERNAL_ERROR")));
+  }
+}


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ x ] Ensure the tests and linter pass
- [ x ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

This change makes error matching against stream rst more robust.  Customers have started to see other variants with RST stream.  The capitalization of "Rst Stream" isn't clear, other repose have it lower cased: (e.g. https://github.com/googleapis/java-bigtable-hbase/pull/3000/files)
