### PR TITLE
fix: Make EOS Matching more robust

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
@@ -31,10 +31,11 @@ public class Errors {
     String description = status.getDescription();
     return status.getCode() == Status.Code.INTERNAL
         && description != null
-        && (description.contains("Received unexpected EOS on DATA frame from server")
+        && (description.contains("Received unexpected EOS ")
             || description.contains(" Rst ")
             || description.contains("RST_STREAM")
             || description.contains("Connection closed with unknown cause")
-            || description.contains("HTTP/2 error code: INTERNAL_ERROR"));
+            || description.contains("HTTP/2 error code: INTERNAL_ERROR")
+            || description.contains("Received unexpected EOS");
   }
 }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
@@ -35,7 +35,6 @@ public class Errors {
             || description.contains(" Rst ")
             || description.contains("RST_STREAM")
             || description.contains("Connection closed with unknown cause")
-            || description.contains("HTTP/2 error code: INTERNAL_ERROR")
-            || description.contains("Received unexpected EOS");
+            || description.contains("HTTP/2 error code: INTERNAL_ERROR"));
   }
 }


### PR DESCRIPTION
fix: Make EOS Matching more robust

Clients are seeing a different variant now: Received unexpected EOS on empty DATA frame from server

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
