### PR TITLE
samples: indicate offset in append operation explicitly in a comment

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
@@ -74,7 +74,7 @@ public class WriteCommittedStream {
 
           // To detect duplicate records, pass the index as the record offset.
           // To disable deduplication, omit the offset or use WriteStream.Type.DEFAULT.
-          ApiFuture<AppendRowsResponse> future = writer.append(jsonArr, i);
+          ApiFuture<AppendRowsResponse> future = writer.append(jsonArr, /*offset=*/ i);
           AppendRowsResponse response = future.get();
         }
       }


### PR DESCRIPTION
Make "offset" stand out a bit more in this append example because it's an important param to ensure ordering and deduplication.