### PR TITLE
docs: user-provided streamOrTableName for default write streams

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
@@ -183,8 +183,8 @@ public class JsonStreamWriter implements AutoCloseable {
    * StreamWriter by default.
    *
    * @param streamOrTableName name of the stream that must follow
-   *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+/streams/[^/]+" or
-   *     table name "projects/[^/]+/datasets/[^/]+/tables/[^/]+"
+   *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+/streams/[^/]+" or table name
+   *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+"
    * @param tableSchema The schema of the table when the stream was created, which is passed back
    *     through {@code WriteStream}
    * @return Builder

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java
@@ -183,9 +183,8 @@ public class JsonStreamWriter implements AutoCloseable {
    * StreamWriter by default.
    *
    * @param streamOrTableName name of the stream that must follow
-   *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+/streams/[^/]+" or if it is default stream
-   *     (createDefaultStream is true on builder), then the name here should be a table name
-   *     ""projects/[^/]+/datasets/[^/]+/tables/[^/]+"
+   *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+/streams/[^/]+" or
+   *     table name "projects/[^/]+/datasets/[^/]+/tables/[^/]+"
    * @param tableSchema The schema of the table when the stream was created, which is passed back
    *     through {@code WriteStream}
    * @return Builder
@@ -260,7 +259,7 @@ public class JsonStreamWriter implements AutoCloseable {
      *
      * @param streamOrTableName name of the stream that must follow
      *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+/streams/[^/]+" or
-     *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+/_default"
+     *     "projects/[^/]+/datasets/[^/]+/tables/[^/]+"
      * @param tableSchema schema used to convert Json to proto messages.
      * @param client
      */

--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
@@ -52,7 +52,7 @@ public class WriteToDefaultStream {
 
     // Use the JSON stream writer to send records in JSON format.
     // For more information about JsonStreamWriter, see:
-    // https://googleapis.dev/java/google-cloud-bigquerystorage/latest/com/google/cloud/bigquery/storage/v1beta2/JstreamWriter.html
+    // https://googleapis.dev/java/google-cloud-bigquerystorage/latest/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.html
     try (JsonStreamWriter writer =
         JsonStreamWriter.newBuilder(parentTable.toString(), schema).build()) {
       // Append 10 JSON objects to the stream.


### PR DESCRIPTION
Fixes a broken URL in a sample comment.

Also cleans up the docstrings for `streamOrTableName` in `JsonStreamWriter.Builder`.

IIUC, `createDefaultStream` can only be set to True on `StreamWriter` not `JsonStreamWriter`, the language below could mislead devs into thinking otherwise because it's not clear which `builder` it refers to.  
https://github.com/googleapis/java-bigquerystorage/blob/d6c3146d21282d1e0724583f68a31184d2d7167b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java#L185-L188

Also it looks like `_default` is not added by client code but by the library.
https://github.com/googleapis/java-bigquerystorage/blob/d6c3146d21282d1e0724583f68a31184d2d7167b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.java#L267-L274

Not sure if I'm making all the right calls here. Thanks for reviewing!

---
Also see internal cl/381977832.