### PR TITLE
Expand Bytes Field type handling

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessage.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessage.java
@@ -144,7 +144,32 @@ public class JsonToProtoMessage {
         if (val instanceof ByteString) {
           protoMsg.setField(fieldDescriptor, ((ByteString) val).toByteArray());
           return;
-        }
+        } else if (val instanceof JSONArray) {
+            try {
+              byte[] bytes = new byte[((JSONArray) val).length()];
+              for (int j = 0; j < ((JSONArray) val).length(); j++) {
+                bytes[j] = (byte) ((JSONArray) val).getInt(j);
+                if (bytes[j] != ((JSONArray) val).getInt(j)) {
+                  throw new IllegalArgumentException(
+                      String.format(
+                          "Error: "
+                              + currentScope
+                              + "["
+                              + index
+                              + "] could not be converted to byte[]."));
+                }
+              }
+              protoMsg.setField(fieldDescriptor, bytes);
+            } catch (JSONException e) {
+              throw new IllegalArgumentException(
+                  String.format(
+                      "Error: "
+                          + currentScope
+                          + "["
+                          + index
+                          + "] could not be converted to byte[]."));
+            }
+          }
         break;
       case INT64:
         if (val instanceof Integer) {
@@ -261,6 +286,9 @@ public class JsonToProtoMessage {
                           + index
                           + "] could not be converted to byte[]."));
             }
+          } else if (val instanceof ByteString){
+            protoMsg.addRepeatedField(fieldDescriptor, ((ByteString) val).toByteArray());
+            return;
           } else {
             fail = true;
           }


### PR DESCRIPTION
Add the ability for a single BYTES field to handle a JSONArray of bytes, and add the ability for a repeated BYTES field to handle a ByteString.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
