### PR TITLE
docs(sample): Fix `PERMISSION_DENIED` in `WriteCommittedStream`

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
@@ -62,7 +62,7 @@ public class WriteCommittedStream {
       // For more information about JsonStreamWriter, see:
       // https://googleapis.dev/java/google-cloud-bigquerystorage/latest/com/google/cloud/bigquery/storage/v1beta2/JsonStreamWriter.html
       try (JsonStreamWriter writer =
-          JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema(), client)
+          JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema())
               .build()) {
         // Append 10 JSON objects to the stream.
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
See details in #1246 .

This is a suggestion from Google's support (Case#28707078) which I am documenting here in case others stumble upon this issue.

It is odd that passing the `client` triggers the error therefore this PR only aims to fix the sample rather than working out the production code (which is still in PRE-GA so issues are expected). Feel free to close this PR if the production code is fixed instead in the meantime (which is preferable).

Let me know if I need add more details on the issue. I omitted as the linked ticket includes the details.

Fixes #1246 ☕️

--- 

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- ~[ ] Code coverage does not decrease (if any source code was changed)~
- [ ] Appropriate docs were updated (if necessary)

