### PR TITLE
feat: retry certain RESOURCE_EXHAUSTED errors observed during ReadRows and report retry attempts

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/util/Errors.java
@@ -15,11 +15,52 @@
  */
 package com.google.cloud.bigquery.storage.util;
 
+import com.google.rpc.RetryInfo;
+import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.protobuf.ProtoUtils;
+import org.threeten.bp.Duration;
 
 /** Static utility methods for working with Errors returned from the service. */
 public class Errors {
   private Errors() {};
+
+  public static class IsRetryableStatusResult {
+    public boolean isRetryable = false;
+    public Duration retryDelay = null;
+  }
+
+  private static final Metadata.Key<RetryInfo> KEY_RETRY_INFO =
+      ProtoUtils.keyForProto(RetryInfo.getDefaultInstance());
+
+  /**
+   * Returns true iff the Status indicates an error that is retryable.
+   *
+   * <p>Generally, internal errors are not considered retryable, however there are certain transient
+   * network issues that appear as internal but are in fact retryable.
+   *
+   * <p>Resource exhausted errors are only considered retryable if metadata contains a serialized
+   * RetryInfo object.
+   */
+  public static IsRetryableStatusResult isRetryableStatus(Status status, Metadata metadata) {
+    IsRetryableStatusResult result = new IsRetryableStatusResult();
+
+    result.isRetryable = isRetryableInternalStatus(status);
+    if (!result.isRetryable
+        && status.getCode() == Status.Code.RESOURCE_EXHAUSTED
+        && metadata != null
+        && metadata.containsKey(KEY_RETRY_INFO)) {
+      RetryInfo retryInfo = metadata.get(KEY_RETRY_INFO);
+      if (retryInfo.hasRetryDelay()) {
+        result.isRetryable = true;
+        result.retryDelay =
+            Duration.ofSeconds(
+                retryInfo.getRetryDelay().getSeconds(), retryInfo.getRetryDelay().getNanos());
+      }
+    }
+
+    return result;
+  }
 
   /**
    * Returns true iff the Status indicates and internal error that is retryable.

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
@@ -126,7 +126,9 @@ public class BigQueryReadClient implements BackgroundResource {
    */
   protected BigQueryReadClient(BigQueryReadSettings settings) throws IOException {
     this.settings = settings;
-    this.stub = EnhancedBigQueryReadStub.create(settings.getTypedStubSettings());
+    this.stub =
+        EnhancedBigQueryReadStub.create(
+            settings.getTypedStubSettings(), settings.getReadRowsRetryAttemptListener());
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadSettings.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadSettings.java
@@ -27,6 +27,8 @@ import com.google.api.gax.rpc.ServerStreamingCallSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStubSettings;
+import io.grpc.Metadata;
+import io.grpc.Status;
 import java.io.IOException;
 import java.util.List;
 
@@ -67,6 +69,26 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
   /** Returns the object with the settings used for calls to readRows. */
   public ServerStreamingCallSettings<ReadRowsRequest, ReadRowsResponse> readRowsSettings() {
     return getTypedStubSettings().readRowsSettings();
+  }
+
+  public static interface RetryAttemptListener {
+    public void onRetryAttempt(Status prevStatus, Metadata prevMetadata);
+  }
+
+  private RetryAttemptListener readRowsRetryAttemptListener = null;
+
+  /**
+   * If a non null readRowsRetryAttemptListener is provided, client will call onRetryAttempt
+   * function before a failed ReadRows request is retried. This can be used as negative feedback
+   * mechanism for future decision to split read streams because some retried failures are due to
+   * resource exhaustion that increased parallelism only makes it worse.
+   */
+  public void setReadRowsRetryAttemptListener(RetryAttemptListener readRowsRetryAttemptListener) {
+    this.readRowsRetryAttemptListener = readRowsRetryAttemptListener;
+  }
+
+  public RetryAttemptListener getReadRowsRetryAttemptListener() {
+    return readRowsRetryAttemptListener;
   }
 
   /** Returns the object with the settings used for calls to splitReadStream. */
@@ -176,6 +198,14 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
       return this;
     }
 
+    private RetryAttemptListener readRowsRetryAttemptListener = null;
+
+    public Builder setReadRowsRetryAttemptListener(
+        RetryAttemptListener readRowsRetryAttemptListener) {
+      this.readRowsRetryAttemptListener = readRowsRetryAttemptListener;
+      return this;
+    }
+
     /** Returns the builder for the settings used for calls to createReadSession. */
     public UnaryCallSettings.Builder<CreateReadSessionRequest, ReadSession>
         createReadSessionSettings() {
@@ -196,7 +226,9 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
 
     @Override
     public BigQueryReadSettings build() throws IOException {
-      return new BigQueryReadSettings(this);
+      BigQueryReadSettings settings = new BigQueryReadSettings(this);
+      settings.setReadRowsRetryAttemptListener(readRowsRetryAttemptListener);
+      return settings;
     }
   }
 }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStub.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStub.java
@@ -31,6 +31,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.gax.tracing.SpanName;
 import com.google.api.gax.tracing.TracedServerStreamingCallable;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadGrpc;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadSettings;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
@@ -54,9 +55,17 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   private static final String TRACING_OUTER_CLIENT_NAME = "BigQueryStorage";
   private final GrpcBigQueryReadStub stub;
   private final BigQueryReadStubSettings stubSettings;
+  private final BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener;
   private final ClientContext context;
 
   public static EnhancedBigQueryReadStub create(EnhancedBigQueryReadStubSettings settings)
+      throws IOException {
+    return create(settings, null);
+  }
+
+  public static EnhancedBigQueryReadStub create(
+      EnhancedBigQueryReadStubSettings settings,
+      BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener)
       throws IOException {
     // Configure the base settings.
     BigQueryReadStubSettings.Builder baseSettingsBuilder =
@@ -88,14 +97,19 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
     BigQueryReadStubSettings baseSettings = baseSettingsBuilder.build();
     ClientContext clientContext = ClientContext.create(baseSettings);
     GrpcBigQueryReadStub stub = new GrpcBigQueryReadStub(baseSettings, clientContext);
-    return new EnhancedBigQueryReadStub(stub, baseSettings, clientContext);
+    return new EnhancedBigQueryReadStub(
+        stub, baseSettings, readRowsRetryAttemptListener, clientContext);
   }
 
   @InternalApi("Visible for testing")
   EnhancedBigQueryReadStub(
-      GrpcBigQueryReadStub stub, BigQueryReadStubSettings stubSettings, ClientContext context) {
+      GrpcBigQueryReadStub stub,
+      BigQueryReadStubSettings stubSettings,
+      BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener,
+      ClientContext context) {
     this.stub = stub;
     this.stubSettings = stubSettings;
+    this.readRowsRetryAttemptListener = readRowsRetryAttemptListener;
     this.context = context;
   }
 
@@ -123,7 +137,7 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
 
     StreamingRetryAlgorithm<Void> retryAlgorithm =
         new StreamingRetryAlgorithm<>(
-            new ApiResultRetryAlgorithm<Void>(),
+            new ApiResultRetryAlgorithm<Void>(readRowsRetryAttemptListener),
             new ExponentialRetryAlgorithm(callSettings.getRetrySettings(), context.getClock()));
 
     ScheduledRetryingExecutor<Void> retryingExecutor =

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/BigQueryStorageClient.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/BigQueryStorageClient.java
@@ -141,7 +141,9 @@ public class BigQueryStorageClient implements BackgroundResource {
    */
   protected BigQueryStorageClient(BigQueryStorageSettings settings) throws IOException {
     this.settings = settings;
-    this.stub = EnhancedBigQueryStorageStub.create(settings.getTypedStubSettings());
+    this.stub =
+        EnhancedBigQueryStorageStub.create(
+            settings.getTypedStubSettings(), settings.getReadRowsRetryAttemptListener());
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/readrows/ApiResultRetryAlgorithm.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/readrows/ApiResultRetryAlgorithm.java
@@ -21,6 +21,8 @@ import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.api.gax.retrying.TimedAttemptSettings;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.bigquery.storage.util.Errors;
+import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageSettings;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import org.threeten.bp.Duration;
 
@@ -30,17 +32,42 @@ public class ApiResultRetryAlgorithm<ResponseT> implements ResultRetryAlgorithm<
   // Duration to sleep on if the error is DEADLINE_EXCEEDED.
   public static final Duration DEADLINE_SLEEP_DURATION = Duration.ofMillis(1);
 
+  private final BigQueryStorageSettings.RetryAttemptListener retryAttemptListener;
+
+  public ApiResultRetryAlgorithm() {
+    this(null);
+  }
+
+  public ApiResultRetryAlgorithm(
+      BigQueryStorageSettings.RetryAttemptListener retryAttemptListener) {
+    super();
+    this.retryAttemptListener = retryAttemptListener;
+  }
+
   @Override
   public TimedAttemptSettings createNextAttempt(
       Throwable prevThrowable, ResponseT prevResponse, TimedAttemptSettings prevSettings) {
     if (prevThrowable != null) {
       Status status = Status.fromThrowable(prevThrowable);
-      if (Errors.isRetryableInternalStatus(status)) {
+      Metadata metadata = Status.trailersFromThrowable(prevThrowable);
+      Errors.IsRetryableStatusResult result = Errors.isRetryableStatus(status, metadata);
+      if (result.isRetryable) {
+        // If result.retryDelay isn't null, we know exactly how long we must wait, so both regular
+        // and randomized delays are the same.
+        Duration retryDelay = result.retryDelay;
+        Duration randomizedRetryDelay = result.retryDelay;
+        if (retryDelay == null) {
+          retryDelay = prevSettings.getRetryDelay();
+          randomizedRetryDelay = DEADLINE_SLEEP_DURATION;
+        }
+        if (retryAttemptListener != null) {
+          retryAttemptListener.onRetryAttempt(status, metadata);
+        }
         return TimedAttemptSettings.newBuilder()
             .setGlobalSettings(prevSettings.getGlobalSettings())
-            .setRetryDelay(prevSettings.getRetryDelay())
+            .setRetryDelay(retryDelay)
             .setRpcTimeout(prevSettings.getRpcTimeout())
-            .setRandomizedRetryDelay(DEADLINE_SLEEP_DURATION)
+            .setRandomizedRetryDelay(randomizedRetryDelay)
             .setAttemptCount(prevSettings.getAttemptCount() + 1)
             .setFirstAttemptStartTimeNanos(prevSettings.getFirstAttemptStartTimeNanos())
             .build();
@@ -53,7 +80,8 @@ public class ApiResultRetryAlgorithm<ResponseT> implements ResultRetryAlgorithm<
   public boolean shouldRetry(Throwable prevThrowable, ResponseT prevResponse) {
     if (prevThrowable != null) {
       Status status = Status.fromThrowable(prevThrowable);
-      if (Errors.isRetryableInternalStatus(status)) {
+      Metadata metadata = Status.trailersFromThrowable(prevThrowable);
+      if (Errors.isRetryableStatus(status, metadata).isRetryable) {
         return true;
       }
     }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/BigQueryReadClient.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/BigQueryReadClient.java
@@ -126,7 +126,9 @@ public class BigQueryReadClient implements BackgroundResource {
    */
   protected BigQueryReadClient(BigQueryReadSettings settings) throws IOException {
     this.settings = settings;
-    this.stub = EnhancedBigQueryReadStub.create(settings.getTypedStubSettings());
+    this.stub =
+        EnhancedBigQueryReadStub.create(
+            settings.getTypedStubSettings(), settings.getReadRowsRetryAttemptListener());
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/EnhancedBigQueryReadStub.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/EnhancedBigQueryReadStub.java
@@ -31,6 +31,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.gax.tracing.SpanName;
 import com.google.api.gax.tracing.TracedServerStreamingCallable;
 import com.google.cloud.bigquery.storage.v1beta2.BigQueryReadGrpc;
+import com.google.cloud.bigquery.storage.v1beta2.BigQueryReadSettings;
 import com.google.cloud.bigquery.storage.v1beta2.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1beta2.ReadRowsResponse;
@@ -54,9 +55,17 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   private static final String TRACING_OUTER_CLIENT_NAME = "BigQueryStorage";
   private final GrpcBigQueryReadStub stub;
   private final BigQueryReadStubSettings stubSettings;
+  private final BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener;
   private final ClientContext context;
 
   public static EnhancedBigQueryReadStub create(EnhancedBigQueryReadStubSettings settings)
+      throws IOException {
+    return create(settings, null);
+  }
+
+  public static EnhancedBigQueryReadStub create(
+      EnhancedBigQueryReadStubSettings settings,
+      BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener)
       throws IOException {
     // Configure the base settings.
     BigQueryReadStubSettings.Builder baseSettingsBuilder =
@@ -88,14 +97,19 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
     BigQueryReadStubSettings baseSettings = baseSettingsBuilder.build();
     ClientContext clientContext = ClientContext.create(baseSettings);
     GrpcBigQueryReadStub stub = new GrpcBigQueryReadStub(baseSettings, clientContext);
-    return new EnhancedBigQueryReadStub(stub, baseSettings, clientContext);
+    return new EnhancedBigQueryReadStub(
+        stub, baseSettings, readRowsRetryAttemptListener, clientContext);
   }
 
   @InternalApi("Visible for testing")
   EnhancedBigQueryReadStub(
-      GrpcBigQueryReadStub stub, BigQueryReadStubSettings stubSettings, ClientContext context) {
+      GrpcBigQueryReadStub stub,
+      BigQueryReadStubSettings stubSettings,
+      BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener,
+      ClientContext context) {
     this.stub = stub;
     this.stubSettings = stubSettings;
+    this.readRowsRetryAttemptListener = readRowsRetryAttemptListener;
     this.context = context;
   }
 
@@ -123,7 +137,7 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
 
     StreamingRetryAlgorithm<Void> retryAlgorithm =
         new StreamingRetryAlgorithm<>(
-            new ApiResultRetryAlgorithm<Void>(),
+            new ApiResultRetryAlgorithm<Void>(readRowsRetryAttemptListener),
             new ExponentialRetryAlgorithm(callSettings.getRetrySettings(), context.getClock()));
 
     ScheduledRetryingExecutor<Void> retryingExecutor =

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/readrows/ApiResultRetryAlgorithm.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/readrows/ApiResultRetryAlgorithm.java
@@ -21,6 +21,8 @@ import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.api.gax.retrying.TimedAttemptSettings;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.bigquery.storage.util.Errors;
+import com.google.cloud.bigquery.storage.v1beta2.BigQueryReadSettings;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import org.threeten.bp.Duration;
 
@@ -30,17 +32,41 @@ public class ApiResultRetryAlgorithm<ResponseT> implements ResultRetryAlgorithm<
   // Duration to sleep on if the error is DEADLINE_EXCEEDED.
   public static final Duration DEADLINE_SLEEP_DURATION = Duration.ofMillis(1);
 
+  private final BigQueryReadSettings.RetryAttemptListener retryAttemptListener;
+
+  public ApiResultRetryAlgorithm() {
+    this(null);
+  }
+
+  public ApiResultRetryAlgorithm(BigQueryReadSettings.RetryAttemptListener retryAttemptListener) {
+    super();
+    this.retryAttemptListener = retryAttemptListener;
+  }
+
   @Override
   public TimedAttemptSettings createNextAttempt(
       Throwable prevThrowable, ResponseT prevResponse, TimedAttemptSettings prevSettings) {
     if (prevThrowable != null) {
       Status status = Status.fromThrowable(prevThrowable);
-      if (Errors.isRetryableInternalStatus(status)) {
+      Metadata metadata = Status.trailersFromThrowable(prevThrowable);
+      Errors.IsRetryableStatusResult result = Errors.isRetryableStatus(status, metadata);
+      if (result.isRetryable) {
+        // If result.retryDelay isn't null, we know exactly how long we must wait, so both regular
+        // and randomized delays are the same.
+        Duration retryDelay = result.retryDelay;
+        Duration randomizedRetryDelay = result.retryDelay;
+        if (retryDelay == null) {
+          retryDelay = prevSettings.getRetryDelay();
+          randomizedRetryDelay = DEADLINE_SLEEP_DURATION;
+        }
+        if (retryAttemptListener != null) {
+          retryAttemptListener.onRetryAttempt(status, metadata);
+        }
         return TimedAttemptSettings.newBuilder()
             .setGlobalSettings(prevSettings.getGlobalSettings())
-            .setRetryDelay(prevSettings.getRetryDelay())
+            .setRetryDelay(retryDelay)
             .setRpcTimeout(prevSettings.getRpcTimeout())
-            .setRandomizedRetryDelay(DEADLINE_SLEEP_DURATION)
+            .setRandomizedRetryDelay(randomizedRetryDelay)
             .setAttemptCount(prevSettings.getAttemptCount() + 1)
             .setFirstAttemptStartTimeNanos(prevSettings.getFirstAttemptStartTimeNanos())
             .build();
@@ -53,7 +79,8 @@ public class ApiResultRetryAlgorithm<ResponseT> implements ResultRetryAlgorithm<
   public boolean shouldRetry(Throwable prevThrowable, ResponseT prevResponse) {
     if (prevThrowable != null) {
       Status status = Status.fromThrowable(prevThrowable);
-      if (Errors.isRetryableInternalStatus(status)) {
+      Metadata metadata = Status.trailersFromThrowable(prevThrowable);
+      if (Errors.isRetryableStatus(status, metadata).isRetryable) {
         return true;
       }
     }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/util/ErrorsTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/util/ErrorsTest.java
@@ -15,9 +15,15 @@
  */
 package com.google.cloud.bigquery.storage.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.Duration;
+import com.google.protobuf.Parser;
+import com.google.rpc.RetryInfo;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,5 +56,79 @@ public class ErrorsTest {
         Errors.isRetryableInternalStatus(
             Status.DATA_LOSS.withDescription(
                 "RST_STREAM closed stream. HTTP/2 error code: INTERNAL_ERROR")));
+  }
+
+  @Test
+  public void testIsRetryableStatus() {
+    Errors.IsRetryableStatusResult result =
+        Errors.isRetryableStatus(
+            Status.INTERNAL.withDescription(
+                "HTTP/2 error code: INTERNAL_ERROR\nReceived Rst stream"),
+            null);
+    assertTrue(result.isRetryable);
+    assertNull(result.retryDelay);
+
+    result =
+        Errors.isRetryableStatus(
+            Status.INTERNAL.withDescription(
+                "RST_STREAM closed stream. HTTP/2 error code: INTERNAL_ERROR"),
+            null);
+    assertTrue(result.isRetryable);
+    assertNull(result.retryDelay);
+
+    Metadata metadata = new Metadata();
+    metadata.put(
+        Metadata.Key.of(
+            "some-key-bin",
+            new Metadata.BinaryMarshaller<Integer>() {
+              @Override
+              public byte[] toBytes(Integer value) {
+                return new byte[] {};
+              }
+
+              @Override
+              public Integer parseBytes(byte[] serialized) {
+                return new Integer(1);
+              }
+            }),
+        new Integer(2));
+    result =
+        Errors.isRetryableStatus(
+            Status.RESOURCE_EXHAUSTED.withDescription("You have run out of X quota"), metadata);
+    assertFalse(result.isRetryable);
+    assertNull(result.retryDelay);
+
+    RetryInfo retryInfo =
+        RetryInfo.newBuilder()
+            .setRetryDelay(Duration.newBuilder().setSeconds(123).setNanos(456).build())
+            .build();
+
+    metadata = new Metadata();
+    metadata.put(
+        Metadata.Key.of(
+            "google.rpc.retryinfo-bin",
+            new Metadata.BinaryMarshaller<RetryInfo>() {
+              @Override
+              public byte[] toBytes(RetryInfo value) {
+                return value.toByteArray();
+              }
+
+              @Override
+              public RetryInfo parseBytes(byte[] serialized) {
+                try {
+                  Parser<RetryInfo> parser = (RetryInfo.newBuilder().build()).getParserForType();
+                  return parser.parseFrom(serialized);
+                } catch (Exception e) {
+                  return null;
+                }
+              }
+            }),
+        retryInfo);
+
+    result =
+        Errors.isRetryableStatus(
+            Status.RESOURCE_EXHAUSTED.withDescription("Stop for a while"), metadata);
+    assertTrue(result.isRetryable);
+    assertEquals(result.retryDelay, org.threeten.bp.Duration.ofSeconds(123, 456));
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClientTest.java
@@ -26,9 +26,14 @@ import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.InternalException;
 import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.ResourceExhaustedException;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Parser;
+import com.google.rpc.RetryInfo;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -49,6 +54,8 @@ public class BigQueryReadClientTest {
   private static MockServiceHelper serviceHelper;
   private BigQueryReadClient client;
   private LocalChannelProvider channelProvider;
+  private int retryCount;
+  private Code lastRetryStatusCode;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -68,10 +75,22 @@ public class BigQueryReadClientTest {
   public void setUp() throws IOException {
     serviceHelper.reset();
     channelProvider = serviceHelper.createChannelProvider();
+    retryCount = 0;
+    lastRetryStatusCode = Code.OK;
     BigQueryReadSettings settings =
         BigQueryReadSettings.newBuilder()
             .setTransportChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
+            .setReadRowsRetryAttemptListener(
+                new BigQueryReadSettings.RetryAttemptListener() {
+                  @Override
+                  public void onRetryAttempt(Status prevStatus, Metadata prevMetadata) {
+                    synchronized (this) {
+                      retryCount += 1;
+                      lastRetryStatusCode = prevStatus.getCode();
+                    }
+                  }
+                })
             .build();
     client = BigQueryReadClient.create(settings);
   }
@@ -143,6 +162,9 @@ public class BigQueryReadClientTest {
     List<ReadRowsResponse> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
     Assert.assertEquals(expectedResponse, actualResponses.get(0));
+
+    Assert.assertEquals(retryCount, 0);
+    Assert.assertEquals(lastRetryStatusCode, Code.OK);
   }
 
   @Test
@@ -165,6 +187,9 @@ public class BigQueryReadClientTest {
       InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
       Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
     }
+
+    Assert.assertEquals(retryCount, 0);
+    Assert.assertEquals(lastRetryStatusCode, Code.OK);
   }
 
   @Test
@@ -189,6 +214,9 @@ public class BigQueryReadClientTest {
     callable.serverStreamingCall(request, responseObserver);
     List<ReadRowsResponse> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
+
+    Assert.assertEquals(retryCount, 1);
+    Assert.assertEquals(lastRetryStatusCode, Code.INTERNAL);
   }
 
   @Test
@@ -213,5 +241,97 @@ public class BigQueryReadClientTest {
     callable.serverStreamingCall(request, responseObserver);
     List<ReadRowsResponse> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
+
+    Assert.assertEquals(retryCount, 1);
+    Assert.assertEquals(lastRetryStatusCode, Code.INTERNAL);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void readRowsNoRetryForResourceExhaustedWithoutRetryInfo()
+      throws ExecutionException, InterruptedException {
+    ApiException exception =
+        new ResourceExhaustedException(
+            new StatusRuntimeException(
+                Status.RESOURCE_EXHAUSTED.withDescription("You are out of quota X")),
+            GrpcStatusCode.of(Code.RESOURCE_EXHAUSTED),
+            /* retryable = */ false);
+    mockBigQueryRead.addException(exception);
+    long rowCount = 1340416618L;
+    ReadRowsResponse expectedResponse = ReadRowsResponse.newBuilder().setRowCount(rowCount).build();
+    mockBigQueryRead.addResponse(expectedResponse);
+    ReadRowsRequest request = ReadRowsRequest.newBuilder().build();
+
+    MockStreamObserver<ReadRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> callable = client.readRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<ReadRowsResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof ResourceExhaustedException);
+      ResourceExhaustedException apiException = (ResourceExhaustedException) e.getCause();
+      Assert.assertEquals(
+          StatusCode.Code.RESOURCE_EXHAUSTED, apiException.getStatusCode().getCode());
+    }
+
+    Assert.assertEquals(retryCount, 0);
+    Assert.assertEquals(lastRetryStatusCode, Code.OK);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void readRowsNoRetryForResourceExhaustedWithRetryInfo()
+      throws ExecutionException, InterruptedException {
+    RetryInfo retryInfo =
+        RetryInfo.newBuilder()
+            .setRetryDelay(Duration.newBuilder().setSeconds(123).setNanos(456).build())
+            .build();
+
+    Metadata metadata = new Metadata();
+    metadata.put(
+        Metadata.Key.of(
+            "google.rpc.retryinfo-bin",
+            new Metadata.BinaryMarshaller<RetryInfo>() {
+              @Override
+              public byte[] toBytes(RetryInfo value) {
+                return value.toByteArray();
+              }
+
+              @Override
+              public RetryInfo parseBytes(byte[] serialized) {
+                try {
+                  Parser<RetryInfo> parser = (RetryInfo.newBuilder().build()).getParserForType();
+                  return parser.parseFrom(serialized);
+                } catch (Exception e) {
+                  return null;
+                }
+              }
+            }),
+        retryInfo);
+
+    ApiException exception =
+        new ResourceExhaustedException(
+            new StatusRuntimeException(
+                Status.RESOURCE_EXHAUSTED.withDescription("Try again in a bit"), metadata),
+            GrpcStatusCode.of(Code.RESOURCE_EXHAUSTED),
+            /* retryable = */ false);
+    mockBigQueryRead.addException(exception);
+    long rowCount = 1340416618L;
+    ReadRowsResponse expectedResponse = ReadRowsResponse.newBuilder().setRowCount(rowCount).build();
+    mockBigQueryRead.addResponse(expectedResponse);
+    ReadRowsRequest request = ReadRowsRequest.newBuilder().build();
+
+    MockStreamObserver<ReadRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> callable = client.readRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+    List<ReadRowsResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+
+    Assert.assertEquals(retryCount, 1);
+    Assert.assertEquals(lastRetryStatusCode, Code.RESOURCE_EXHAUSTED);
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/BigQueryReadClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/BigQueryReadClientTest.java
@@ -26,9 +26,14 @@ import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.InternalException;
 import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.ResourceExhaustedException;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Parser;
+import com.google.rpc.RetryInfo;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -49,6 +54,8 @@ public class BigQueryReadClientTest {
   private static MockServiceHelper serviceHelper;
   private BigQueryReadClient client;
   private LocalChannelProvider channelProvider;
+  private int retryCount;
+  private Code lastRetryStatusCode;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -68,10 +75,22 @@ public class BigQueryReadClientTest {
   public void setUp() throws IOException {
     serviceHelper.reset();
     channelProvider = serviceHelper.createChannelProvider();
+    retryCount = 0;
+    lastRetryStatusCode = Code.OK;
     BigQueryReadSettings settings =
         BigQueryReadSettings.newBuilder()
             .setTransportChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
+            .setReadRowsRetryAttemptListener(
+                new BigQueryReadSettings.RetryAttemptListener() {
+                  @Override
+                  public void onRetryAttempt(Status prevStatus, Metadata prevMetadata) {
+                    synchronized (this) {
+                      retryCount += 1;
+                      lastRetryStatusCode = prevStatus.getCode();
+                    }
+                  }
+                })
             .build();
     client = BigQueryReadClient.create(settings);
   }
@@ -143,6 +162,9 @@ public class BigQueryReadClientTest {
     List<ReadRowsResponse> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
     Assert.assertEquals(expectedResponse, actualResponses.get(0));
+
+    Assert.assertEquals(retryCount, 0);
+    Assert.assertEquals(lastRetryStatusCode, Code.OK);
   }
 
   @Test
@@ -165,6 +187,9 @@ public class BigQueryReadClientTest {
       InvalidArgumentException apiException = (InvalidArgumentException) e.getCause();
       Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
     }
+
+    Assert.assertEquals(retryCount, 0);
+    Assert.assertEquals(lastRetryStatusCode, Code.OK);
   }
 
   @Test
@@ -189,6 +214,9 @@ public class BigQueryReadClientTest {
     callable.serverStreamingCall(request, responseObserver);
     List<ReadRowsResponse> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
+
+    Assert.assertEquals(retryCount, 1);
+    Assert.assertEquals(lastRetryStatusCode, Code.INTERNAL);
   }
 
   @Test
@@ -213,5 +241,97 @@ public class BigQueryReadClientTest {
     callable.serverStreamingCall(request, responseObserver);
     List<ReadRowsResponse> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
+
+    Assert.assertEquals(retryCount, 1);
+    Assert.assertEquals(lastRetryStatusCode, Code.INTERNAL);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void readRowsNoRetryForResourceExhaustedWithoutRetryInfo()
+      throws ExecutionException, InterruptedException {
+    ApiException exception =
+        new ResourceExhaustedException(
+            new StatusRuntimeException(
+                Status.RESOURCE_EXHAUSTED.withDescription("You are out of quota X")),
+            GrpcStatusCode.of(Code.RESOURCE_EXHAUSTED),
+            /* retryable = */ false);
+    mockBigQueryRead.addException(exception);
+    long rowCount = 1340416618L;
+    ReadRowsResponse expectedResponse = ReadRowsResponse.newBuilder().setRowCount(rowCount).build();
+    mockBigQueryRead.addResponse(expectedResponse);
+    ReadRowsRequest request = ReadRowsRequest.newBuilder().build();
+
+    MockStreamObserver<ReadRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> callable = client.readRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<ReadRowsResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof ResourceExhaustedException);
+      ResourceExhaustedException apiException = (ResourceExhaustedException) e.getCause();
+      Assert.assertEquals(
+          StatusCode.Code.RESOURCE_EXHAUSTED, apiException.getStatusCode().getCode());
+    }
+
+    Assert.assertEquals(retryCount, 0);
+    Assert.assertEquals(lastRetryStatusCode, Code.OK);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void readRowsNoRetryForResourceExhaustedWithRetryInfo()
+      throws ExecutionException, InterruptedException {
+    RetryInfo retryInfo =
+        RetryInfo.newBuilder()
+            .setRetryDelay(Duration.newBuilder().setSeconds(123).setNanos(456).build())
+            .build();
+
+    Metadata metadata = new Metadata();
+    metadata.put(
+        Metadata.Key.of(
+            "google.rpc.retryinfo-bin",
+            new Metadata.BinaryMarshaller<RetryInfo>() {
+              @Override
+              public byte[] toBytes(RetryInfo value) {
+                return value.toByteArray();
+              }
+
+              @Override
+              public RetryInfo parseBytes(byte[] serialized) {
+                try {
+                  Parser<RetryInfo> parser = (RetryInfo.newBuilder().build()).getParserForType();
+                  return parser.parseFrom(serialized);
+                } catch (Exception e) {
+                  return null;
+                }
+              }
+            }),
+        retryInfo);
+
+    ApiException exception =
+        new ResourceExhaustedException(
+            new StatusRuntimeException(
+                Status.RESOURCE_EXHAUSTED.withDescription("Try again in a bit"), metadata),
+            GrpcStatusCode.of(Code.RESOURCE_EXHAUSTED),
+            /* retryable = */ false);
+    mockBigQueryRead.addException(exception);
+    long rowCount = 1340416618L;
+    ReadRowsResponse expectedResponse = ReadRowsResponse.newBuilder().setRowCount(rowCount).build();
+    mockBigQueryRead.addResponse(expectedResponse);
+    ReadRowsRequest request = ReadRowsRequest.newBuilder().build();
+
+    MockStreamObserver<ReadRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> callable = client.readRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+    List<ReadRowsResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+
+    Assert.assertEquals(retryCount, 1);
+    Assert.assertEquals(lastRetryStatusCode, Code.RESOURCE_EXHAUSTED);
   }
 }


### PR DESCRIPTION
Bq Storage Read service will start returning a retryable RESOURCE_EXHAUSTED error in the next few weeks when a read session's parallelism is considered to be excessive, so this PR expands retry handling logic for ReadRows with 2 changes:
1. If a ReadRows request fails with a RESOURCE_EXHAUSTED error and the error has an associated RetryInfo, it is now considered to be retryable and retry delay is set according to the RetryInfo.
1. If the client decides to retry, it now notifies the user with the provided RetryAttemptListener object. This will be useful as a negative feedback mechanism for future SplitReadStream requests which in return will reduce the likelihood of receiving the new retryable RESOURCE_EXHAUSTED error.