### PR TITLE
revert: "chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.24"

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.23</version>
   </parent>
 
   <properties>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.23</version>
   </parent>
 
   <properties>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.23</version>
   </parent>
 
   <properties>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.23</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
Reverts googleapis/java-bigquerystorage#1428

Due to below error caused:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check (default-cli) on project bigquerystorage-snippets: Execution default-cli of goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check failed: Plugin org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2 or one of its dependencies could not be resolved: Could not find artifact com.google.cloud.samples:checkstyle-configuration:jar:1.0.24 in central (https://repo.maven.apache.org/maven2) -> [Help 1```