### PR TITLE
fix(java): add reflection configuration for native-image testing

### DIFF
--- a/google-cloud-bigquerystorage/src/test/resources/META-INF/native-image/reflect-config.json
+++ b/google-cloud-bigquerystorage/src/test/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name":"java.lang.Object",
+    "allDeclaredFields":true,
+    "queryAllDeclaredMethods":true,
+    "methods":[{"name":"<init>","parameterTypes":[] }]}
+]


### PR DESCRIPTION
This PR adds reflection configuration for native-image testing. Currently running `mvn test -Pnative` caused `ITBigQueryWriteManualClientTest` to fail at the native image build step. 

```
Caused by: java.lang.IllegalArgumentException: key v, field private java.lang.Object com.google.api.services.bigquery.model.TableCell.v
       com.google.api.client.json.JsonParser.parseValue(JsonParser.java:900)
       com.google.api.client.json.JsonParser.parse(JsonParser.java:451)
       com.google.api.client.json.JsonParser.parseValue(JsonParser.java:787)
       [...]
     Caused by: java.lang.IllegalArgumentException: unable to create new instance of class java.lang.Object because it has no accessible default constructor
       com.google.api.client.util.Types.handleExceptionForNewInstance(Types.java:162)
       com.google.api.client.util.Types.newInstance(Types.java:117)
       com.google.api.client.util.Data.createNullInstance(Data.java:166)
       com.google.api.client.util.Data.nullOf(Data.java:134)
       com.google.api.client.json.JsonParser.parseValue(JsonParser.java:883)
       [...]
     Caused by: java.lang.InstantiationException: Type `java.lang.Object` can not be instantiated reflectively as it does not have a no-parameter constructor or the no-parameter constructor has not been added explicitly to the native image.
       java.lang.Class.newInstance(DynamicHub.java:915)
       com.google.api.client.util.Types.newInstance(Types.java:113)
       [...]
```
During native image build, the builder performs static analysis to determine which classes are reachable from the entry-point of the application. Sometimes usages of Java reflection don't get recognized and [need to be registered](https://www.graalvm.org/22.0/reference-manual/native-image/Agent/) to let the builder know which classes to include in the binary. 
