### PR TITLE
deps: exclude un-used runtime dependencies brought in by gax-grpc

### DIFF
--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -95,6 +95,28 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-xds</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-services</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.re2j</groupId>
+          <artifactId>re2j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>opencensus-proto</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>


### PR DESCRIPTION
Fixes b/216195517

Exclude:
```
io.grpc:grpc-xds:jar:1.42.1:runtime

io.grpc:grpc-services:jar:1.42.1:runtime

com.google.re2j:re2j:jar:1.5:runtime

org.bouncycastle:bcprov-jdk15on:jar:1.67:runtime

io.opencensus:opencensus-proto:0.2.0:runtime
```