### PR TITLE
deps: upgrade google-cloud-shared-dependencies to v2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This addresses gRPC CVE by upgarding to v1.44.0. Note that gRPC dropped Java 8 support in this version.
