### PR TITLE
fix: Add a e2e test on byte string array and remove a impossible case…

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
@@ -441,9 +441,6 @@ public class JsonToProtoMessage {
                             + index
                             + "] could not be converted to byte[]."));
               }
-            } else if (val instanceof ByteString) {
-              protoMsg.addRepeatedField(fieldDescriptor, ((ByteString) val).toByteArray());
-              return;
             } else {
               fail = true;
             }


### PR DESCRIPTION
Per internal bug b/219375453, it seems JSON object doesn't support cast of ByteString, so remove the ByteString case in repeated field conversion since it is not possible.

JSONArray jsonArray = new JSONArray(new ByteString[]{ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("b")}); LOG.info("" + (jsonArray.get(0) instanceof ByteString)); 
LOG.info("" + ((ByteString)jsonArray.get(0)).toByteArray());


INFO: *****false

java.lang.ClassCastException: class org.json.JSONObject cannot be cast to class com.google.protobuf.ByteString (org.json.JSONObject and com.google.protobuf.ByteString are in unnamed module of loader 'app')