### PR TITLE
fix: ints/longs are numerics

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
@@ -290,6 +290,12 @@ public class JsonToProtoMessage {
                   BigDecimalByteStringEncoder.encodeToNumericByteString(
                       new BigDecimal((String) val)));
               return;
+            } else if (val instanceof Integer || val instanceof Long) {
+              protoMsg.setField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
+              return;
             }
           } else if (fieldSchema.getType() == TableFieldSchema.Type.BIGNUMERIC) {
             if (val instanceof String) {
@@ -297,6 +303,12 @@ public class JsonToProtoMessage {
                   fieldDescriptor,
                   BigDecimalByteStringEncoder.encodeToBigNumericByteString(
                       new BigDecimal((String) val)));
+              return;
+            } else if (val instanceof Integer || val instanceof Long) {
+              protoMsg.setField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToBigNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
               return;
             }
           }
@@ -504,6 +516,12 @@ public class JsonToProtoMessage {
                   BigDecimalByteStringEncoder.encodeToNumericByteString(
                       new BigDecimal((String) val)));
               added = true;
+            } else if (val instanceof Integer || val instanceof Long) {
+              protoMsg.addRepeatedField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
+              added = true;
             }
           } else if (fieldSchema != null
               && fieldSchema.getType() == TableFieldSchema.Type.BIGNUMERIC) {
@@ -512,6 +530,12 @@ public class JsonToProtoMessage {
                   fieldDescriptor,
                   BigDecimalByteStringEncoder.encodeToBigNumericByteString(
                       new BigDecimal((String) val)));
+              added = true;
+            } else if (val instanceof Integer || val instanceof Long) {
+              protoMsg.addRepeatedField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToBigNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
               added = true;
             }
           }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessage.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessage.java
@@ -197,6 +197,12 @@ public class JsonToProtoMessage {
                   BigDecimalByteStringEncoder.encodeToNumericByteString(
                       new BigDecimal((String) val)));
               return;
+            } else if (val instanceof Long || val instanceof Integer) {
+              protoMsg.setField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
+              return;
             }
           } else if (fieldSchema.getType() == TableFieldSchema.Type.BIGNUMERIC) {
             if (val instanceof String) {
@@ -204,6 +210,12 @@ public class JsonToProtoMessage {
                   fieldDescriptor,
                   BigDecimalByteStringEncoder.encodeToNumericByteString(
                       new BigDecimal((String) val)));
+              return;
+            } else if (val instanceof Long || val instanceof Integer) {
+              protoMsg.setField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
               return;
             }
           }
@@ -357,6 +369,12 @@ public class JsonToProtoMessage {
                   BigDecimalByteStringEncoder.encodeToNumericByteString(
                       new BigDecimal((String) val)));
               added = true;
+            } else if (val instanceof Long || val instanceof Integer) {
+              protoMsg.addRepeatedField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
+              added = true;
             }
           } else if (fieldSchema != null
               && fieldSchema.getType() == TableFieldSchema.Type.BIGNUMERIC) {
@@ -365,6 +383,12 @@ public class JsonToProtoMessage {
                   fieldDescriptor,
                   BigDecimalByteStringEncoder.encodeToNumericByteString(
                       new BigDecimal((String) val)));
+              added = true;
+            } else if (val instanceof Long || val instanceof Integer) {
+              protoMsg.addRepeatedField(
+                  fieldDescriptor,
+                  BigDecimalByteStringEncoder.encodeToNumericByteString(
+                      new BigDecimal(((Number) val).longValue())));
               added = true;
             }
           }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/BQTableSchemaToProtoDescriptorTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/BQTableSchemaToProtoDescriptorTest.java
@@ -233,6 +233,18 @@ public class BQTableSchemaToProtoDescriptorTest {
             .setMode(TableFieldSchema.Mode.NULLABLE)
             .setName("test_numeric_str")
             .build();
+    final TableFieldSchema TEST_NUMERIC_INT =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.NUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_numeric_int")
+            .build();
+    final TableFieldSchema TEST_NUMERIC_LONG =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.NUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_numeric_long")
+            .build();
     final TableFieldSchema TEST_BIGNUMERIC =
         TableFieldSchema.newBuilder()
             .setType(TableFieldSchema.Type.BIGNUMERIC)
@@ -244,6 +256,18 @@ public class BQTableSchemaToProtoDescriptorTest {
             .setType(TableFieldSchema.Type.BIGNUMERIC)
             .setMode(TableFieldSchema.Mode.REPEATED)
             .setName("test_bignumeric_str")
+            .build();
+    final TableFieldSchema TEST_BIGNUMERIC_INT =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.BIGNUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_bignumeric_int")
+            .build();
+    final TableFieldSchema TEST_BIGNUMERIC_LONG =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.BIGNUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_bignumeric_long")
             .build();
     final TableFieldSchema TEST_INTERVAL =
         TableFieldSchema.newBuilder()
@@ -276,10 +300,14 @@ public class BQTableSchemaToProtoDescriptorTest {
             .addFields(14, TEST_TIME_STR)
             .addFields(15, TEST_NUMERIC_REPEATED)
             .addFields(16, TEST_NUMERIC_STR)
-            .addFields(17, TEST_BIGNUMERIC)
-            .addFields(18, TEST_BIGNUMERIC_STR)
-            .addFields(19, TEST_INTERVAL)
-            .addFields(20, TEST_JSON)
+            .addFields(17, TEST_NUMERIC_INT)
+            .addFields(18, TEST_NUMERIC_LONG)
+            .addFields(19, TEST_BIGNUMERIC)
+            .addFields(20, TEST_BIGNUMERIC_STR)
+            .addFields(21, TEST_BIGNUMERIC_INT)
+            .addFields(22, TEST_BIGNUMERIC_LONG)
+            .addFields(23, TEST_INTERVAL)
+            .addFields(24, TEST_JSON)
             .build();
     final Descriptor descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(tableSchema);

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessageTest.java
@@ -409,6 +409,18 @@ public class JsonToProtoMessageTest {
           .setMode(TableFieldSchema.Mode.NULLABLE)
           .setName("test_numeric_str")
           .build();
+  private final TableFieldSchema TEST_NUMERIC_INT =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.NUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_numeric_int")
+          .build();
+  private final TableFieldSchema TEST_NUMERIC_LONG =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.NUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_numeric_long")
+          .build();
   private final TableFieldSchema TEST_BIGNUMERIC =
       TableFieldSchema.newBuilder()
           .setType(TableFieldSchema.Type.BIGNUMERIC)
@@ -420,6 +432,18 @@ public class JsonToProtoMessageTest {
           .setType(TableFieldSchema.Type.BIGNUMERIC)
           .setMode(TableFieldSchema.Mode.REPEATED)
           .setName("test_bignumeric_str")
+          .build();
+  private final TableFieldSchema TEST_BIGNUMERIC_INT =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.BIGNUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_bignumeric_int")
+          .build();
+  private final TableFieldSchema TEST_BIGNUMERIC_LONG =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.BIGNUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_bignumeric_long")
           .build();
   final TableFieldSchema TEST_INTERVAL =
       TableFieldSchema.newBuilder()
@@ -452,10 +476,14 @@ public class JsonToProtoMessageTest {
           .addFields(14, TEST_TIME_STR)
           .addFields(15, TEST_NUMERIC_REPEATED)
           .addFields(16, TEST_NUMERIC_STR)
-          .addFields(17, TEST_BIGNUMERIC)
-          .addFields(18, TEST_BIGNUMERIC_STR)
-          .addFields(19, TEST_INTERVAL)
-          .addFields(20, TEST_JSON)
+          .addFields(17, TEST_NUMERIC_INT)
+          .addFields(18, TEST_NUMERIC_LONG)
+          .addFields(19, TEST_BIGNUMERIC)
+          .addFields(20, TEST_BIGNUMERIC_STR)
+          .addFields(21, TEST_BIGNUMERIC_INT)
+          .addFields(22, TEST_BIGNUMERIC_LONG)
+          .addFields(23, TEST_INTERVAL)
+          .addFields(24, TEST_JSON)
           .build();
 
   @Test
@@ -888,11 +916,19 @@ public class JsonToProtoMessageTest {
                     new BigDecimal("-99999999999999999999999999999.999999999")))
             .setTestNumericStr(
                 BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal("12.4")))
+            .setTestNumericInt(
+                BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal(1)))
+            .setTestNumericLong(
+                BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal(1L)))
             .setTestBignumeric(
                 BigDecimalByteStringEncoder.encodeToBigNumericByteString(
                     new BigDecimal("578960446186580977117854925043439539266.3")))
             .addTestBignumericStr(
                 BigDecimalByteStringEncoder.encodeToBigNumericByteString(new BigDecimal("1.23")))
+            .setTestBignumericInt(
+                BigDecimalByteStringEncoder.encodeToBigNumericByteString(new BigDecimal(1)))
+            .setTestBignumericLong(
+                BigDecimalByteStringEncoder.encodeToBigNumericByteString(new BigDecimal(1L)))
             .setTestInterval("0-0 0 0:0:0.000005")
             .addTestJson("{'a':'b'}")
             .build();
@@ -937,11 +973,15 @@ public class JsonToProtoMessageTest {
     json.put("test_time", CivilTimeEncoder.encodePacked64TimeMicros(LocalTime.of(1, 0, 1)));
     json.put("test_time_str", "20:51:10.1234");
     json.put("test_numeric_str", "12.4");
+    json.put("test_numeric_int", 1);
+    json.put("test_numeric_long", 1L);
     json.put(
         "test_bignumeric",
         BigDecimalByteStringEncoder.encodeToBigNumericByteString(
             new BigDecimal("578960446186580977117854925043439539266.3")));
     json.put("test_bignumeric_str", new JSONArray(new String[] {"1.23"}));
+    json.put("test_bignumeric_int", 1);
+    json.put("test_bignumeric_long", 1L);
     json.put("test_interval", "0-0 0 0:0:0.000005");
     json.put("test_json", new JSONArray(new String[] {"{'a':'b'}"}));
     DynamicMessage protoMsg =

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/BQTableSchemaToProtoDescriptorTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/BQTableSchemaToProtoDescriptorTest.java
@@ -233,6 +233,18 @@ public class BQTableSchemaToProtoDescriptorTest {
             .setMode(TableFieldSchema.Mode.NULLABLE)
             .setName("test_numeric_str")
             .build();
+    final TableFieldSchema TEST_NUMERIC_INT =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.NUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_numeric_int")
+            .build();
+    final TableFieldSchema TEST_NUMERIC_LONG =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.NUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_numeric_long")
+            .build();
     final TableFieldSchema TEST_BIGNUMERIC =
         TableFieldSchema.newBuilder()
             .setType(TableFieldSchema.Type.NUMERIC)
@@ -244,6 +256,18 @@ public class BQTableSchemaToProtoDescriptorTest {
             .setType(TableFieldSchema.Type.NUMERIC)
             .setMode(TableFieldSchema.Mode.REPEATED)
             .setName("test_bignumeric_str")
+            .build();
+    final TableFieldSchema TEST_BIGNUMERIC_INT =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.NUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_bignumeric_int")
+            .build();
+    final TableFieldSchema TEST_BIGNUMERIC_LONG =
+        TableFieldSchema.newBuilder()
+            .setType(TableFieldSchema.Type.NUMERIC)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .setName("test_bignumeric_long")
             .build();
     final TableFieldSchema TEST_INTERVAL =
         TableFieldSchema.newBuilder()
@@ -276,10 +300,14 @@ public class BQTableSchemaToProtoDescriptorTest {
             .addFields(14, TEST_TIME_STR)
             .addFields(15, TEST_NUMERIC_REPEATED)
             .addFields(16, TEST_NUMERIC_STR)
-            .addFields(17, TEST_BIGNUMERIC)
-            .addFields(18, TEST_BIGNUMERIC_STR)
-            .addFields(19, TEST_INTERVAL)
-            .addFields(20, TEST_JSON)
+            .addFields(17, TEST_NUMERIC_INT)
+            .addFields(18, TEST_NUMERIC_LONG)
+            .addFields(19, TEST_BIGNUMERIC)
+            .addFields(20, TEST_BIGNUMERIC_STR)
+            .addFields(21, TEST_BIGNUMERIC_INT)
+            .addFields(22, TEST_BIGNUMERIC_LONG)
+            .addFields(23, TEST_INTERVAL)
+            .addFields(24, TEST_JSON)
             .build();
     final Descriptor descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(tableSchema);

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/JsonToProtoMessageTest.java
@@ -386,6 +386,18 @@ public class JsonToProtoMessageTest {
           .setMode(TableFieldSchema.Mode.NULLABLE)
           .setName("test_numeric_str")
           .build();
+  private final TableFieldSchema TEST_NUMERIC_INT =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.NUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_numeric_int")
+          .build();
+  private final TableFieldSchema TEST_NUMERIC_LONG =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.NUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_numeric_long")
+          .build();
   private final TableFieldSchema TEST_BIGNUMERIC =
       TableFieldSchema.newBuilder()
           .setType(TableFieldSchema.Type.NUMERIC)
@@ -397,6 +409,18 @@ public class JsonToProtoMessageTest {
           .setType(TableFieldSchema.Type.NUMERIC)
           .setMode(TableFieldSchema.Mode.REPEATED)
           .setName("test_bignumeric_str")
+          .build();
+  private final TableFieldSchema TEST_BIGNUMERIC_INT =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.NUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_bignumeric_int")
+          .build();
+  private final TableFieldSchema TEST_BIGNUMERIC_LONG =
+      TableFieldSchema.newBuilder()
+          .setType(TableFieldSchema.Type.NUMERIC)
+          .setMode(TableFieldSchema.Mode.NULLABLE)
+          .setName("test_bignumeric_long")
           .build();
   private final TableFieldSchema TEST_INTERVAL =
       TableFieldSchema.newBuilder()
@@ -429,10 +453,14 @@ public class JsonToProtoMessageTest {
           .addFields(14, TEST_TIME_STR)
           .addFields(15, TEST_NUMERIC_REPEATED)
           .addFields(16, TEST_NUMERIC_STR)
-          .addFields(17, TEST_BIGNUMERIC)
-          .addFields(18, TEST_BIGNUMERIC_STR)
-          .addFields(19, TEST_INTERVAL)
-          .addFields(20, TEST_JSON)
+          .addFields(17, TEST_NUMERIC_INT)
+          .addFields(18, TEST_NUMERIC_LONG)
+          .addFields(19, TEST_BIGNUMERIC)
+          .addFields(20, TEST_BIGNUMERIC_STR)
+          .addFields(21, TEST_BIGNUMERIC_INT)
+          .addFields(22, TEST_BIGNUMERIC_LONG)
+          .addFields(23, TEST_INTERVAL)
+          .addFields(24, TEST_JSON)
           .build();
 
   @Test
@@ -777,10 +805,18 @@ public class JsonToProtoMessageTest {
                     new BigDecimal("-99999999999999999999999999999.999999999")))
             .setTestNumericStr(
                 BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal("12.4")))
+            .setTestNumericInt(
+                BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal(1)))
+            .setTestNumericLong(
+                BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal(1L)))
             .setTestBignumeric(
                 BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal("2.3")))
             .addTestBignumericStr(
                 BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal("1.23")))
+            .setTestBignumericInt(
+                BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal(1)))
+            .setTestBignumericLong(
+                BigDecimalByteStringEncoder.encodeToNumericByteString(new BigDecimal(1L)))
             .setTestInterval("0-0 0 0:0:0.000005")
             .addTestJson("{'a':'b'}")
             .build();
@@ -825,10 +861,14 @@ public class JsonToProtoMessageTest {
     json.put("test_time", CivilTimeEncoder.encodePacked64TimeMicros(LocalTime.of(1, 0, 1)));
     json.put("test_time_str", "20:51:10.1234");
     json.put("test_numeric_str", "12.4");
+    json.put("test_numeric_int", 1);
+    json.put("test_numeric_long", 1L);
     json.put(
         "test_bignumeric",
         BigDecimalByteStringEncoder.encodeToNumericByteString(BigDecimal.valueOf(2.3)));
     json.put("test_bignumeric_str", new JSONArray(new String[] {"1.23"}));
+    json.put("test_bignumeric_int", 1);
+    json.put("test_bignumeric_long", 1L);
     json.put("test_interval", "0-0 0 0:0:0.000005");
     json.put("test_json", new JSONArray(new String[] {"{'a':'b'}"}));
     DynamicMessage protoMsg =

--- a/google-cloud-bigquerystorage/src/test/proto/jsonTest.proto
+++ b/google-cloud-bigquerystorage/src/test/proto/jsonTest.proto
@@ -21,10 +21,14 @@ message ComplexRoot {
   optional int64 test_time_str = 15;
   repeated bytes test_numeric_repeated = 16;
   optional bytes test_numeric_str = 17;
-  optional bytes test_bignumeric = 18;
-  repeated bytes test_bignumeric_str = 19;
-  optional string test_interval = 20;
-  repeated string test_json = 21;
+  optional bytes test_numeric_int = 18;
+  optional bytes test_numeric_long = 19;
+  optional bytes test_bignumeric = 20;
+  repeated bytes test_bignumeric_str = 21;
+  optional bytes test_bignumeric_int = 22;
+  optional bytes test_bignumeric_long = 23;
+  optional string test_interval = 24;
+  repeated string test_json = 25;
 }
 
 message CasingComplex {


### PR DESCRIPTION
Should allow users to pass ints and longs as numerics.

Fixes #1516
