### PR TITLE
fix: A stuck when the client fail to get DoneCallback

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -506,9 +506,9 @@ public class StreamWriter implements AutoCloseable {
       }
       Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
     }
-    connectionFinalStatus = new StatusRuntimeException(
-        Status.fromCode(Code.CANCELLED)
-            .withDescription("Timeout waiting for DoneCallback."));
+    connectionFinalStatus =
+        new StatusRuntimeException(
+            Status.fromCode(Code.CANCELLED).withDescription("Timeout waiting for DoneCallback."));
     return;
   }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -465,7 +465,7 @@ public class StreamWriter implements AutoCloseable {
     // We can close the stream connection and handle the remaining inflight requests.
     if (streamConnection != null) {
       this.streamConnection.close();
-      waitForDoneCallback();
+      waitForDoneCallback(1, TimeUnit.MINUTES);
     }
 
     // At this point, there cannot be more callback. It is safe to clean up all inflight requests.
@@ -491,9 +491,10 @@ public class StreamWriter implements AutoCloseable {
     }
   }
 
-  private void waitForDoneCallback() {
+  private void waitForDoneCallback(long duration, TimeUnit timeUnit) {
     log.fine("Waiting for done callback from stream connection. Stream: " + streamName);
-    while (true) {
+    long deadline = System.nanoTime() + timeUnit.toNanos(duration);
+    while (System.nanoTime() <= deadline) {
       this.lock.lock();
       try {
         if (connectionFinalStatus != null) {
@@ -505,6 +506,10 @@ public class StreamWriter implements AutoCloseable {
       }
       Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
     }
+    connectionFinalStatus = new StatusRuntimeException(
+        Status.fromCode(Code.CANCELLED)
+            .withDescription("Timeout waiting for DoneCallback."));
+    return;
   }
 
   private AppendRowsRequest prepareRequestBasedOnPosition(

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -507,12 +507,17 @@ public class StreamWriter implements AutoCloseable {
       Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
     }
     this.lock.lock();
-    if (connectionFinalStatus == null) {
-      connectionFinalStatus =
-          new StatusRuntimeException(
-              Status.fromCode(Code.CANCELLED).withDescription("Timeout waiting for DoneCallback."));
+    try {
+      if (connectionFinalStatus == null) {
+        connectionFinalStatus =
+            new StatusRuntimeException(
+                Status.fromCode(Code.CANCELLED)
+                    .withDescription("Timeout waiting for DoneCallback."));
+      }
+    } finally {
+      this.lock.unlock();
     }
-    this.lock.unlock();
+
     return;
   }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -506,9 +506,11 @@ public class StreamWriter implements AutoCloseable {
       }
       Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
     }
-    connectionFinalStatus =
-        new StatusRuntimeException(
-            Status.fromCode(Code.CANCELLED).withDescription("Timeout waiting for DoneCallback."));
+    if (connectionFinalStatus == null) {
+      connectionFinalStatus =
+          new StatusRuntimeException(
+              Status.fromCode(Code.CANCELLED).withDescription("Timeout waiting for DoneCallback."));
+    }
     return;
   }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -506,11 +506,13 @@ public class StreamWriter implements AutoCloseable {
       }
       Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
     }
+    this.lock.lock();
     if (connectionFinalStatus == null) {
       connectionFinalStatus =
           new StatusRuntimeException(
               Status.fromCode(Code.CANCELLED).withDescription("Timeout waiting for DoneCallback."));
     }
+    this.lock.unlock();
     return;
   }
 


### PR DESCRIPTION
Add a timeout of one minute waiting for done callback to be called. Same timeout as client close.
The donecallback mainly gives back the server side error status, so it is not critical. In Dataflow connector, we saw hang because the DoneCallback is lost and we wait forever on it.

Stack trace in b/230501926
