### PR TITLE
fix: Fix a possible NULL PTR after introduced timeout on waitForDone

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -573,6 +573,9 @@ public class StreamWriter implements AutoCloseable {
         conectionRetryCountWithoutCallback = 0;
       }
       requestWrapper = pollInflightRequestQueue();
+      if (requestWrapper == null) {
+        return;
+      }
     } finally {
       this.lock.unlock();
     }
@@ -640,11 +643,17 @@ public class StreamWriter implements AutoCloseable {
 
   @GuardedBy("lock")
   private AppendRequestAndResponse pollInflightRequestQueue() {
-    AppendRequestAndResponse requestWrapper = this.inflightRequestQueue.pollFirst();
-    --this.inflightRequests;
-    this.inflightBytes -= requestWrapper.messageSize;
-    this.inflightReduced.signal();
-    return requestWrapper;
+    if (!this.inflightRequestQueue.isEmpty()) {
+      AppendRequestAndResponse requestWrapper = this.inflightRequestQueue.pollFirst();
+      --this.inflightRequests;
+      this.inflightBytes -= requestWrapper.messageSize;
+      this.inflightReduced.signal();
+      return requestWrapper;
+    } else {
+      // It is possible when requestCallback is called, the inflight queue is already drained to do timeout waiting
+      // for done.
+      return null;
+    }
   }
 
   /**

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -465,7 +465,7 @@ public class StreamWriter implements AutoCloseable {
     // We can close the stream connection and handle the remaining inflight requests.
     if (streamConnection != null) {
       this.streamConnection.close();
-      waitForDoneCallback(1, TimeUnit.MINUTES);
+      waitForDoneCallback(2, TimeUnit.MINUTES);
     }
 
     // At this point, there cannot be more callback. It is safe to clean up all inflight requests.
@@ -650,7 +650,8 @@ public class StreamWriter implements AutoCloseable {
       this.inflightReduced.signal();
       return requestWrapper;
     } else {
-      // It is possible when requestCallback is called, the inflight queue is already drained to do timeout waiting
+      // It is possible when requestCallback is called, the inflight queue is already drained to do
+      // timeout waiting
       // for done.
       return null;
     }


### PR DESCRIPTION
This PR:
https://github.com/googleapis/java-bigquerystorage/pull/1637

introduced a timeout for waitForDone. So we could potentially drained the inflight requests when a RequestCallback comes back. Add process for null when peak the inflight queue.
