### PR TITLE
fix: Add a throwException behavior when the StreamWriter inflight queue is full

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.12.2'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.13.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.12.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.13.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -78,6 +78,8 @@ public class JsonStreamWriter implements AutoCloseable {
     this.protoSchema = ProtoSchemaConverter.convert(this.descriptor);
     this.totalMessageSize = protoSchema.getSerializedSize();
     streamWriterBuilder.setWriterSchema(protoSchema);
+    streamWriterBuilder.setLimitExceededBehavior(
+        builder.flowControlSettings.getLimitExceededBehavior());
     setStreamWriterSettings(
         builder.channelProvider,
         builder.credentialsProvider,
@@ -214,6 +216,10 @@ public class JsonStreamWriter implements AutoCloseable {
         streamWriterBuilder.setMaxInflightRequests(
             flowControlSettings.getMaxOutstandingElementCount());
       }
+      if (flowControlSettings.getLimitExceededBehavior() != null) {
+        streamWriterBuilder.setLimitExceededBehavior(
+            flowControlSettings.getLimitExceededBehavior());
+      }
     }
   }
 
@@ -335,7 +341,6 @@ public class JsonStreamWriter implements AutoCloseable {
      * @return Builder
      */
     public Builder setFlowControlSettings(FlowControlSettings flowControlSettings) {
-      Preconditions.checkNotNull(flowControlSettings, "FlowControlSettings is null.");
       this.flowControlSettings =
           Preconditions.checkNotNull(flowControlSettings, "FlowControlSettings is null.");
       return this;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -78,8 +78,10 @@ public class JsonStreamWriter implements AutoCloseable {
     this.protoSchema = ProtoSchemaConverter.convert(this.descriptor);
     this.totalMessageSize = protoSchema.getSerializedSize();
     streamWriterBuilder.setWriterSchema(protoSchema);
-    streamWriterBuilder.setLimitExceededBehavior(
-        builder.flowControlSettings.getLimitExceededBehavior());
+    if (builder.flowControlSettings != null) {
+      streamWriterBuilder.setLimitExceededBehavior(
+          builder.flowControlSettings.getLimitExceededBehavior());
+    }
     setStreamWriterSettings(
         builder.channelProvider,
         builder.credentialsProvider,

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -16,8 +16,8 @@
 package com.google.cloud.bigquery.storage.v1;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowControlSettings;

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -15,7 +15,9 @@
  */
 package com.google.cloud.bigquery.storage.v1;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowControlSettings;

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -15,10 +15,11 @@
  */
 package com.google.cloud.bigquery.storage.v1;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
@@ -31,6 +32,8 @@ import com.google.cloud.bigquery.storage.test.Test.UpdatedFooType;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.Timestamp;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
@@ -42,6 +45,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.threeten.bp.Instant;
@@ -538,6 +542,41 @@ public class JsonStreamWriterTest {
       jsonArr.put(bar);
       ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
       appendFuture.get();
+    }
+  }
+
+  @Test
+  public void testFlowControlSetting() throws Exception {
+    TableSchema tableSchema = TableSchema.newBuilder().addFields(0, TEST_INT).build();
+    try (JsonStreamWriter writer =
+        JsonStreamWriter.newBuilder(TEST_STREAM, tableSchema)
+            .setChannelProvider(channelProvider)
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .setFlowControlSettings(
+                FlowControlSettings.newBuilder()
+                    .setLimitExceededBehavior(FlowController.LimitExceededBehavior.ThrowException)
+                    .setMaxOutstandingRequestBytes(1L)
+                    .build())
+            .build()) {
+      JSONObject foo = new JSONObject();
+      foo.put("test_int", 10);
+      JSONArray jsonArr = new JSONArray();
+      jsonArr.put(foo);
+      StatusRuntimeException ex =
+          assertThrows(
+              StatusRuntimeException.class,
+              new ThrowingRunnable() {
+                @Override
+                public void run() throws Throwable {
+                  writer.append(jsonArr);
+                }
+              });
+      assertEquals(ex.getStatus().getCode(), Status.RESOURCE_EXHAUSTED.getCode());
+      assertTrue(
+          ex.getStatus()
+              .getDescription()
+              .contains(
+                  "Exceeds client side inflight buffer, consider add more buffer or open more connections"));
     }
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -15,7 +15,11 @@
  */
 package com.google.cloud.bigquery.storage.v1;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowController;


### PR DESCRIPTION
Add a throwException behavior when the StreamWriter inflight queue is full.

Fixes #1539 ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
