### PR TITLE
fix: add extra JsonWriterTest to show that the LimitBehavior addition is not breaking

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -78,10 +78,6 @@ public class JsonStreamWriter implements AutoCloseable {
     this.protoSchema = ProtoSchemaConverter.convert(this.descriptor);
     this.totalMessageSize = protoSchema.getSerializedSize();
     streamWriterBuilder.setWriterSchema(protoSchema);
-    if (builder.flowControlSettings != null) {
-      streamWriterBuilder.setLimitExceededBehavior(
-          builder.flowControlSettings.getLimitExceededBehavior());
-    }
     setStreamWriterSettings(
         builder.channelProvider,
         builder.credentialsProvider,

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -314,6 +314,7 @@ public class StreamWriter implements AutoCloseable {
                     .withDescription("Connection is already closed")));
         return requestWrapper.appendResult;
       }
+      // Check if queue is going to be full before adding the request.
       if (this.inflightRequests + 1 >= this.maxInflightRequests
           || this.inflightBytes + requestWrapper.messageSize >= this.maxInflightBytes) {
         if (this.limitExceededBehavior == FlowController.LimitExceededBehavior.ThrowException) {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -315,14 +315,13 @@ public class StreamWriter implements AutoCloseable {
         return requestWrapper.appendResult;
       }
       // Check if queue is going to be full before adding the request.
-      if (this.inflightRequests + 1 >= this.maxInflightRequests
-          || this.inflightBytes + requestWrapper.messageSize >= this.maxInflightBytes) {
-        if (this.limitExceededBehavior == FlowController.LimitExceededBehavior.ThrowException) {
-          throw new StatusRuntimeException(
-              Status.fromCode(Code.RESOURCE_EXHAUSTED)
-                  .withDescription(
-                      "Exceeds client side inflight buffer, consider add more buffer or open more connections."));
-        }
+      if ((this.inflightRequests + 1 >= this.maxInflightRequests
+              || this.inflightBytes + requestWrapper.messageSize >= this.maxInflightBytes)
+          && (this.limitExceededBehavior == FlowController.LimitExceededBehavior.ThrowException)) {
+        throw new StatusRuntimeException(
+            Status.fromCode(Code.RESOURCE_EXHAUSTED)
+                .withDescription(
+                    "Exceeds client side inflight buffer, consider add more buffer or open more connections."));
       }
 
       if (connectionFinalStatus != null) {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -314,6 +314,16 @@ public class StreamWriter implements AutoCloseable {
                     .withDescription("Connection is already closed")));
         return requestWrapper.appendResult;
       }
+      if (this.inflightRequests + 1 >= this.maxInflightRequests
+          || this.inflightBytes + requestWrapper.messageSize >= this.maxInflightBytes) {
+        if (this.limitExceededBehavior == FlowController.LimitExceededBehavior.ThrowException) {
+          throw new StatusRuntimeException(
+              Status.fromCode(Code.RESOURCE_EXHAUSTED)
+                  .withDescription(
+                      "Exceeds client side inflight buffer, consider add more buffer or open more connections."));
+        }
+      }
+
       if (connectionFinalStatus != null) {
         requestWrapper.appendResult.setException(
             new StatusRuntimeException(
@@ -339,29 +349,18 @@ public class StreamWriter implements AutoCloseable {
     long start_time = System.currentTimeMillis();
     while (this.inflightRequests >= this.maxInflightRequests
         || this.inflightBytes >= this.maxInflightBytes) {
-      if (this.limitExceededBehavior == FlowController.LimitExceededBehavior.ThrowException) {
+      try {
+        inflightReduced.await(100, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        log.warning(
+            "Interrupted while waiting for inflight quota. Stream: "
+                + streamName
+                + " Error: "
+                + e.toString());
         throw new StatusRuntimeException(
-            Status.fromCode(Code.RESOURCE_EXHAUSTED)
-                .withDescription(
-                    "Exceeds client side inflight buffer, consider add more buffer or open more connections."));
-      } else if (this.limitExceededBehavior == FlowController.LimitExceededBehavior.Ignore) {
-        throw new StatusRuntimeException(
-            Status.fromCode(Code.INVALID_ARGUMENT)
-                .withDescription("LimitExceededBehavior.Ignore is not supported on StreamWriter."));
-      } else {
-        try {
-          inflightReduced.await(100, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-          log.warning(
-              "Interrupted while waiting for inflight quota. Stream: "
-                  + streamName
-                  + " Error: "
-                  + e.toString());
-          throw new StatusRuntimeException(
-              Status.fromCode(Code.CANCELLED)
-                  .withCause(e)
-                  .withDescription("Interrupted while waiting for quota."));
-        }
+            Status.fromCode(Code.CANCELLED)
+                .withCause(e)
+                .withDescription("Interrupted while waiting for quota."));
       }
     }
     inflightWaitSec.set((System.currentTimeMillis() - start_time) / 1000);
@@ -812,7 +811,12 @@ public class StreamWriter implements AutoCloseable {
      * @return
      */
     public Builder setLimitExceededBehavior(
-        FlowController.LimitExceededBehavior limitExceededBehavior) {
+        FlowController.LimitExceededBehavior limitExceededBehavior) throws StatusRuntimeException {
+      if (limitExceededBehavior == FlowController.LimitExceededBehavior.Ignore) {
+        throw new StatusRuntimeException(
+            Status.fromCode(Code.INVALID_ARGUMENT)
+                .withDescription("LimitExceededBehavior.Ignore is not supported on StreamWriter."));
+      }
       this.limitExceededBehavior = limitExceededBehavior;
       return this;
     }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -582,6 +582,8 @@ public class JsonStreamWriterTest {
     }
   }
 
+  // This is to test the new addition didn't break previous settings, i.e., sets the inflight limit without limit
+  // beahviro.
   @Test
   public void testFlowControlSettingNoLimitBehavior() throws Exception {
     TableSchema tableSchema = TableSchema.newBuilder().addFields(0, TEST_INT).build();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -582,20 +582,19 @@ public class JsonStreamWriterTest {
     }
   }
 
-  // This is to test the new addition didn't break previous settings, i.e., sets the inflight limit without limit
-  // beahviro.
+  // This is to test the new addition didn't break previous settings, i.e., sets the inflight limit
+  // without
+  // limit beahvior.
   @Test
   public void testFlowControlSettingNoLimitBehavior() throws Exception {
     TableSchema tableSchema = TableSchema.newBuilder().addFields(0, TEST_INT).build();
     try (JsonStreamWriter writer =
-             JsonStreamWriter.newBuilder(TEST_STREAM, tableSchema)
-                 .setChannelProvider(channelProvider)
-                 .setCredentialsProvider(NoCredentialsProvider.create())
-                 .setFlowControlSettings(
-                     FlowControlSettings.newBuilder()
-                         .setMaxOutstandingRequestBytes(1L)
-                         .build())
-                 .build()) {
+        JsonStreamWriter.newBuilder(TEST_STREAM, tableSchema)
+            .setChannelProvider(channelProvider)
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .setFlowControlSettings(
+                FlowControlSettings.newBuilder().setMaxOutstandingRequestBytes(1L).build())
+            .build()) {
       testBigQueryWrite.addResponse(AppendRowsResponse.newBuilder().build());
       JSONObject foo = new JSONObject();
       foo.put("test_int", 10);

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -583,8 +583,7 @@ public class JsonStreamWriterTest {
   }
 
   // This is to test the new addition didn't break previous settings, i.e., sets the inflight limit
-  // without
-  // limit beahvior.
+  // without limit beahvior.
   @Test
   public void testFlowControlSettingNoLimitBehavior() throws Exception {
     TableSchema tableSchema = TableSchema.newBuilder().addFields(0, TEST_INT).build();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -560,7 +560,6 @@ public class JsonStreamWriterTest {
                     .setMaxOutstandingRequestBytes(1L)
                     .build())
             .build()) {
-      testBigQueryWrite.addResponse(AppendRowsResponse.newBuilder().build());
       JSONObject foo = new JSONObject();
       foo.put("test_int", 10);
       JSONArray jsonArr = new JSONArray();
@@ -595,6 +594,7 @@ public class JsonStreamWriterTest {
                          .setMaxOutstandingRequestBytes(1L)
                          .build())
                  .build()) {
+      testBigQueryWrite.addResponse(AppendRowsResponse.newBuilder().build());
       JSONObject foo = new JSONObject();
       foo.put("test_int", 10);
       JSONArray jsonArr = new JSONArray();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -15,10 +15,7 @@
  */
 package com.google.cloud.bigquery.storage.v1;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowController;

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowController;

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -15,7 +15,11 @@
  */
 package com.google.cloud.bigquery.storage.v1;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowController;


### PR DESCRIPTION
Also change the exception rejection into before the request was added to the queue instead of after.

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
