### PR TITLE
feat: Add another StreamWriterClosedException and remove RETRY_THRESHOLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.16.1'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.17.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.16.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.17.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -119,11 +119,6 @@ public class StreamWriter implements AutoCloseable {
   private boolean inflightCleanuped = false;
 
   /*
-   * Retry threshold, limits how often the connection is retried before processing halts.
-   */
-  private static final long RETRY_THRESHOLD = 3;
-
-  /*
    * Indicates whether user has called Close() or not.
    */
   @GuardedBy("lock")
@@ -327,10 +322,11 @@ public class StreamWriter implements AutoCloseable {
 
       if (connectionFinalStatus != null) {
         requestWrapper.appendResult.setException(
-            new StatusRuntimeException(
+            Exceptions.StreamWriterClosedException(
                 Status.fromCode(Status.Code.FAILED_PRECONDITION)
                     .withDescription(
-                        "Connection is closed due to " + connectionFinalStatus.toString())));
+                        "Connection is closed due to " + connectionFinalStatus.toString()),
+                streamName));
         return requestWrapper.appendResult;
       }
 
@@ -653,9 +649,7 @@ public class StreamWriter implements AutoCloseable {
       this.streamConnectionIsConnected = false;
       if (connectionFinalStatus == null) {
         // If the error can be retried, don't set it here, let it try to retry later on.
-        if (isRetriableError(finalStatus)
-            && conectionRetryCountWithoutCallback < RETRY_THRESHOLD
-            && !userClosed) {
+        if (isRetriableError(finalStatus) && !userClosed) {
           this.conectionRetryCountWithoutCallback++;
           log.fine(
               "Retriable error "

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -322,7 +322,7 @@ public class StreamWriter implements AutoCloseable {
 
       if (connectionFinalStatus != null) {
         requestWrapper.appendResult.setException(
-            Exceptions.StreamWriterClosedException(
+            new Exceptions.StreamWriterClosedException(
                 Status.fromCode(Status.Code.FAILED_PRECONDITION)
                     .withDescription(
                         "Connection is closed due to " + connectionFinalStatus.toString()),

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -662,6 +662,7 @@ public class StreamWriterTest {
     Exceptions.StreamWriterClosedException actualError =
         assertFutureException(Exceptions.StreamWriterClosedException.class, appendFuture1);
     // The basic StatusRuntimeException API is not changed.
+    assertTrue(actualError instanceof StatusRuntimeException);
     assertEquals(Status.Code.FAILED_PRECONDITION, actualError.getStatus().getCode());
     assertTrue(actualError.getStatus().getDescription().contains("Connection is already closed"));
   }
@@ -679,6 +680,7 @@ public class StreamWriterTest {
     Exceptions.StreamWriterClosedException actualError =
         assertFutureException(Exceptions.StreamWriterClosedException.class, appendFuture2);
     // The basic StatusRuntimeException API is not changed.
+    assertTrue(actualError instanceof StatusRuntimeException);
     assertEquals(Status.Code.FAILED_PRECONDITION, actualError.getStatus().getCode());
     assertTrue(actualError.getStatus().getDescription().contains("Connection is closed"));
   }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -655,7 +655,7 @@ public class StreamWriterTest {
   }
 
   @Test
-  public void testWriterException() throws Exception {
+  public void testWriterAlreadyClosedException() throws Exception {
     StreamWriter writer = getTestStreamWriter();
     writer.close();
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"}, 0);
@@ -664,5 +664,22 @@ public class StreamWriterTest {
     // The basic StatusRuntimeException API is not changed.
     assertEquals(Status.Code.FAILED_PRECONDITION, actualError.getStatus().getCode());
     assertTrue(actualError.getStatus().getDescription().contains("Connection is already closed"));
+  }
+
+  @Test
+  public void testWriterClosedException() throws Exception {
+    StreamWriter writer = getTestStreamWriter();
+    testBigQueryWrite.addException(Status.INTERNAL.asException());
+    ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"}, 0);
+    try {
+      appendFuture1.get();
+    } catch (Exception e) {
+    }
+    ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"A"}, 0);
+    Exceptions.StreamWriterClosedException actualError =
+        assertFutureException(Exceptions.StreamWriterClosedException.class, appendFuture2);
+    // The basic StatusRuntimeException API is not changed.
+    assertEquals(Status.Code.FAILED_PRECONDITION, actualError.getStatus().getCode());
+    assertTrue(actualError.getStatus().getDescription().contains("Connection is closed"));
   }
 }


### PR DESCRIPTION
In a retryable error case, if we close the writer, the only thing user can do is to recreate streamwriter and do the same thing. So remove RETRY_THRESHOLD so that user need to worry about one less issue.