### PR TITLE
feat: Add CANCELLED to StreamWriter retryable error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.17.0'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.18.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.17.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.18.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -635,8 +635,8 @@ public class StreamWriter implements AutoCloseable {
     if (Errors.isRetryableInternalStatus(status)) {
       return true;
     }
-    return status.getCode() == Status.Code.ABORTED
-        || status.getCode() == Status.Code.UNAVAILABLE
+    return status.getCode() == Code.ABORTED
+        || status.getCode() == Code.UNAVAILABLE
         || status.getCode() == Code.CANCELLED;
   }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -635,7 +635,9 @@ public class StreamWriter implements AutoCloseable {
     if (Errors.isRetryableInternalStatus(status)) {
       return true;
     }
-    return status.getCode() == Status.Code.ABORTED || status.getCode() == Status.Code.UNAVAILABLE;
+    return status.getCode() == Status.Code.ABORTED
+        || status.getCode() == Status.Code.UNAVAILABLE
+        || status.getCode() == Code.CANCELLED;
   }
 
   private void doneCallback(Throwable finalStatus) {


### PR DESCRIPTION
Customer hitting a general grpc channel cancelled error due to server side cancel the channel:
throwable com.google.cloud.bigquery.storage.v1.Exceptions$StreamWriterClosedException: FAILED_PRECONDITION: Connection is closed due to com.google.api.gax.rpc.CancelledException: io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.

Since we have user_closed flag to guard writer close, it is fine to retry on Cancelled error, so user side saw less error.