### PR TITLE
feat!: remove a dummy WriterClosedException

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.17.0'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.18.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.17.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.18.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -12,8 +12,7 @@
     <method>Exceptions$StreamFinalizedException(io.grpc.Status, io.grpc.Metadata, java.lang.String)</method>
   </difference>
   <difference>
-    <differenceType>7004</differenceType>
+    <differenceType>8001</differenceType>
     <className>com/google/cloud/bigquery/storage/v1/Exceptions$WriterClosedException</className>
-    <method>Exceptions$WriterClosedException(java.lang.String)</method>
   </difference>
 </differences>

--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -11,4 +11,9 @@
     <className>com/google/cloud/bigquery/storage/v1/Exceptions$StreamFinalizedException</className>
     <method>Exceptions$StreamFinalizedException(io.grpc.Status, io.grpc.Metadata, java.lang.String)</method>
   </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/bigquery/storage/v1/Exceptions$WriterClosedException</className>
+    <method>Exceptions$WriterClosedException(java.lang.String)</method>
+  </difference>
 </differences>

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
@@ -29,11 +29,6 @@ import javax.annotation.Nullable;
 
 /** Exceptions for Storage Client Libraries. */
 public final class Exceptions {
-  public static class WriterClosedException extends Exception {
-    public WriterClosedException(String streamName) {
-      super("Writer closed on: " + streamName);
-    }
-  }
   /** Main Storage Exception. Might contain map of streams to errors for that stream. */
   public static class StorageException extends StatusRuntimeException {
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -562,9 +562,10 @@ public class StreamWriter implements AutoCloseable {
   }
 
   private void cleanupInflightRequests() {
-    Throwable finalStatus = new Exceptions.StreamWriterClosedException(
-        Status.fromCode(Status.Code.FAILED_PRECONDITION)
-            .withDescription("Connection is already closed, cleanup inflight request"),
+    Throwable finalStatus =
+        new Exceptions.StreamWriterClosedException(
+            Status.fromCode(Status.Code.FAILED_PRECONDITION)
+                .withDescription("Connection is already closed, cleanup inflight request"),
             streamName);
     Deque<AppendRequestAndResponse> localQueue = new LinkedList<AppendRequestAndResponse>();
     this.lock.lock();

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -562,7 +562,10 @@ public class StreamWriter implements AutoCloseable {
   }
 
   private void cleanupInflightRequests() {
-    Throwable finalStatus = new Exceptions.WriterClosedException(streamName);
+    Throwable finalStatus = new Exceptions.StreamWriterClosedException(
+        Status.fromCode(Status.Code.FAILED_PRECONDITION)
+            .withDescription("Connection is already closed, cleanup inflight request"),
+            streamName);
     Deque<AppendRequestAndResponse> localQueue = new LinkedList<AppendRequestAndResponse>();
     this.lock.lock();
     try {


### PR DESCRIPTION
Remove a dummy WriterClosedException. Because we now have StreamWriterClosedException, remove the WriterClosedException to avoid confusion.

The WriterClosedException is used as a place holder when we cleanup Inflight request. In call cases, we should have gotten a not null connectionFinalStatus in WaitForDoneCallback:
https://github.com/googleapis/java-bigquerystorage/blob/main/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java#L533

So no user should be able to get this exception.