### PR TITLE
deps: fixing the test scope dependency to runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.19.0'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.19.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.19.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.19.1"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -181,7 +181,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Fixing the test-scope dependency to runtime. The flatten maven plugin does not interpret test scope dependency correctly.

The test scope was added recently: https://github.com/googleapis/java-bigquerystorage/pull/1720/files#diff-273690ed1fb8c3821089309482b75cb6b6de18d07238cb82c74cb1855e215904 . This would cause problem like https://github.com/googleapis/java-pubsub/issues/1239
