### PR TITLE
fix: Close based on whether connection is active, not status variable

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -538,7 +538,7 @@ public class StreamWriter implements AutoCloseable {
     while (System.nanoTime() <= deadline) {
       this.lock.lock();
       try {
-        if (connectionFinalStatus != null) {
+        if (!this.streamConnectionIsConnected) {
           // Done callback is received, return.
           return;
         }


### PR DESCRIPTION
Final status isn't set after retriable error, but if we're not connected, there's no point in waiting for a done callback.

Unit tests aren't set up for this, but verified by temporarily adding 10m wait to IT, which works after fix.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
