### PR TITLE
feat: ExecutorProvider can now be replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.1.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.2')
 
 implementation 'com.google.cloud:google-cloud-bigquerystorage'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.20.0'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.21.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.20.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.21.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery.storage.v1;
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError;
 import com.google.common.base.Preconditions;
@@ -84,6 +85,7 @@ public class JsonStreamWriter implements AutoCloseable {
     setStreamWriterSettings(
         builder.channelProvider,
         builder.credentialsProvider,
+        builder.executorProvider,
         builder.endpoint,
         builder.flowControlSettings,
         builder.traceId);
@@ -214,6 +216,7 @@ public class JsonStreamWriter implements AutoCloseable {
   private void setStreamWriterSettings(
       @Nullable TransportChannelProvider channelProvider,
       @Nullable CredentialsProvider credentialsProvider,
+      @Nullable ExecutorProvider executorProvider,
       @Nullable String endpoint,
       @Nullable FlowControlSettings flowControlSettings,
       @Nullable String traceId) {
@@ -222,6 +225,9 @@ public class JsonStreamWriter implements AutoCloseable {
     }
     if (credentialsProvider != null) {
       streamWriterBuilder.setCredentialsProvider(credentialsProvider);
+    }
+    if (executorProvider != null) {
+      streamWriterBuilder.setExecutorProvider(executorProvider);
     }
     if (endpoint != null) {
       streamWriterBuilder.setEndpoint(endpoint);
@@ -295,6 +301,7 @@ public class JsonStreamWriter implements AutoCloseable {
 
     private TransportChannelProvider channelProvider;
     private CredentialsProvider credentialsProvider;
+    private ExecutorProvider executorProvider;
     private FlowControlSettings flowControlSettings;
     private String endpoint;
     private boolean createDefaultStream = false;
@@ -355,6 +362,18 @@ public class JsonStreamWriter implements AutoCloseable {
     public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
       this.credentialsProvider =
           Preconditions.checkNotNull(credentialsProvider, "CredentialsProvider is null.");
+      return this;
+    }
+
+    /**
+     * Setter for the underlying StreamWriter's ExecutorProvider.
+     *
+     * @param executorProvider
+     * @return
+     */
+    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
+      this.executorProvider =
+          Preconditions.checkNotNull(executorProvider, "ExecutorProvider is null.");
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -19,6 +19,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.bigquery.storage.util.Errors;
@@ -206,6 +207,7 @@ public class StreamWriter implements AutoCloseable {
           BigQueryWriteSettings.newBuilder()
               .setCredentialsProvider(builder.credentialsProvider)
               .setTransportChannelProvider(builder.channelProvider)
+              .setBackgroundExecutorProvider(builder.executorProvider)
               .setEndpoint(builder.endpoint)
               // (b/185842996): Temporily fix this by explicitly providing the header.
               .setHeaderProvider(
@@ -752,6 +754,9 @@ public class StreamWriter implements AutoCloseable {
     private CredentialsProvider credentialsProvider =
         BigQueryWriteSettings.defaultCredentialsProviderBuilder().build();
 
+    private ExecutorProvider executorProvider =
+        BigQueryWriteSettings.defaultExecutorProviderBuilder().build();
+
     private FlowController.LimitExceededBehavior limitExceededBehavior =
         FlowController.LimitExceededBehavior.Block;
 
@@ -808,6 +813,12 @@ public class StreamWriter implements AutoCloseable {
     public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
       this.credentialsProvider =
           Preconditions.checkNotNull(credentialsProvider, "CredentialsProvider is null.");
+      return this;
+    }
+
+    /** {@code ExecutorProvider} to use to create Executor to run background jobs. */
+    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
+      this.executorProvider = executorProvider;
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -135,7 +135,8 @@ public class JsonStreamWriterTest {
       String testStream, TableSchema BQTableSchema) {
     return JsonStreamWriter.newBuilder(testStream, BQTableSchema)
         .setChannelProvider(channelProvider)
-        .setCredentialsProvider(NoCredentialsProvider.create());
+        .setCredentialsProvider(NoCredentialsProvider.create())
+        .setExecutorProvider(InstantiatingExecutorProvider.newBuilder().build());
   }
 
   @Test
@@ -394,6 +395,7 @@ public class JsonStreamWriterTest {
         JsonStreamWriter.newBuilder(TEST_TABLE, tableSchema)
             .setChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
+            .setExecutorProvider(InstantiatingExecutorProvider.newBuilder().build())
             .build()) {
       assertEquals("projects/p/datasets/d/tables/t/_default", writer.getStreamName());
     }
@@ -538,6 +540,7 @@ public class JsonStreamWriterTest {
             .setChannelProvider(channelProvider)
             .setIgnoreUnknownFields(true)
             .setCredentialsProvider(NoCredentialsProvider.create())
+            .setExecutorProvider(InstantiatingExecutorProvider.newBuilder().build())
             .build()) {
       testBigQueryWrite.addResponse(AppendRowsResponse.newBuilder().build());
       JSONObject foo = new JSONObject();
@@ -559,6 +562,7 @@ public class JsonStreamWriterTest {
         JsonStreamWriter.newBuilder(TEST_STREAM, tableSchema)
             .setChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
+            .setExecutorProvider(InstantiatingExecutorProvider.newBuilder().build())
             .setFlowControlSettings(
                 FlowControlSettings.newBuilder()
                     .setLimitExceededBehavior(FlowController.LimitExceededBehavior.ThrowException)
@@ -596,6 +600,7 @@ public class JsonStreamWriterTest {
         JsonStreamWriter.newBuilder(TEST_STREAM, tableSchema)
             .setChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
+            .setExecutorProvider(InstantiatingExecutorProvider.newBuilder().build())
             .setFlowControlSettings(
                 FlowControlSettings.newBuilder().setMaxOutstandingRequestBytes(1L).build())
             .build()) {


### PR DESCRIPTION
An arbitrary ExecutorProvider can be set to control the generation of gax threads.

Fixes #1769  