### PR TITLE
feat: always pass a null bigquery client lib to StreamWriter

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -73,11 +73,7 @@ public class JsonStreamWriter implements AutoCloseable {
     this.descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(builder.tableSchema);
 
-    if (this.client == null) {
-      streamWriterBuilder = StreamWriter.newBuilder(builder.streamName);
-    } else {
-      streamWriterBuilder = StreamWriter.newBuilder(builder.streamName, builder.client);
-    }
+    streamWriterBuilder = StreamWriter.newBuilder(builder.streamName);
     this.protoSchema = ProtoSchemaConverter.convert(this.descriptor);
     this.totalMessageSize = protoSchema.getSerializedSize();
     streamWriterBuilder.setWriterSchema(protoSchema);


### PR DESCRIPTION
In order for regional routing to work, right now, we need to recreate a BigQueryWriteClient with custom header on StreamWriter. The new JsonWriter builder interface we added requires a not null BigQueryClient in order to be able to call GetWriteStream, if the user always pass in BigQueryWriteClient, in the current code, we reuses that BigQueryWriteClient and then the customer header will not be added and routing will fail.

So no matter whether we have an existing BigQueryWriteClient or not on the json writer, we always ask StreamWriter to create a new BigQueryWriteClient in order for routing to work. We are working on the backend to make this special workaround no longer needed.
