### PR TITLE
feat: populate location info if we already called GetWriteStream

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -407,6 +407,7 @@ public class JsonStreamWriter implements AutoCloseable {
         TableSchema writeStreamTableSchema = writeStream.getTableSchema();
 
         this.tableSchema = writeStreamTableSchema;
+        this.location = writeStream.getLocation();
       } else {
         this.tableSchema = tableSchema;
       }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -536,6 +536,10 @@ public class JsonStreamWriter implements AutoCloseable {
      * @return Builder
      */
     public Builder setLocation(String location) {
+      if (this.location != null && !this.location.equals(location)) {
+        throw new IllegalArgumentException(
+            "Specified location " + location + " does not match the system value " + this.location);
+      }
       this.location = location;
       return this;
     }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -247,6 +247,15 @@ public class JsonStreamWriter implements AutoCloseable {
   }
 
   /**
+   * Gets the location of the destination
+   *
+   * @return Descriptor
+   */
+  public String getLocation() {
+    return this.streamWriter.getLocation();
+  }
+
+  /**
    * Returns the wait of a request in Client side before sending to the Server. Request could wait
    * in Client because it reached the client side inflight request limit (adjustable when
    * constructing the Writer). The value is the wait time for the last sent request. A constant high

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -52,6 +52,11 @@ public class StreamWriter implements AutoCloseable {
   private final ProtoSchema writerSchema;
 
   /*
+   * Location of the destination.
+   */
+  private final String location;
+
+  /*
    * A String that uniquely identifies this writer.
    */
   private final String writerId = UUID.randomUUID().toString();
@@ -162,6 +167,7 @@ public class StreamWriter implements AutoCloseable {
     BigQueryWriteClient client;
     this.streamName = builder.streamName;
     this.writerSchema = builder.writerSchema;
+    this.location = builder.location;
     boolean ownsBigQueryWriteClient;
     if (builder.client == null) {
       BigQueryWriteSettings stubSettings =
@@ -193,7 +199,7 @@ public class StreamWriter implements AutoCloseable {
                   client,
                   ownsBigQueryWriteClient));
     } else {
-      if (builder.location == "") {
+      if (builder.location == null || builder.location.isEmpty()) {
         throw new IllegalArgumentException("Location must be specified for multiplexing client!");
       }
       // Assume the connection in the same pool share the same client and trace id.
@@ -318,6 +324,11 @@ public class StreamWriter implements AutoCloseable {
     return writerSchema;
   }
 
+  /** @return the location of the destination. */
+  public String getLocation() {
+    return location;
+  }
+
   /** Close the stream writer. Shut down all resources. */
   @Override
   public void close() {
@@ -379,7 +390,7 @@ public class StreamWriter implements AutoCloseable {
 
     private TableSchema updatedTableSchema = null;
 
-    private String location;
+    private String location = null;
 
     private boolean enableConnectionPool = false;
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -393,12 +393,19 @@ public class JsonStreamWriterTest {
   public void testCreateDefaultStream() throws Exception {
     TableSchema tableSchema =
         TableSchema.newBuilder().addFields(0, TEST_INT).addFields(1, TEST_STRING).build();
+    testBigQueryWrite.addResponse(
+        WriteStream.newBuilder()
+            .setName(TEST_STREAM)
+            .setLocation("aa")
+            .setTableSchema(tableSchema)
+            .build());
     try (JsonStreamWriter writer =
-        JsonStreamWriter.newBuilder(TEST_TABLE, tableSchema)
+        JsonStreamWriter.newBuilder(TEST_TABLE, client)
             .setChannelProvider(channelProvider)
             .setCredentialsProvider(NoCredentialsProvider.create())
             .build()) {
       assertEquals("projects/p/datasets/d/tables/t/_default", writer.getStreamName());
+      assertEquals("aa", writer.getLocation());
     }
   }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -410,6 +410,32 @@ public class JsonStreamWriterTest {
   }
 
   @Test
+  public void testCreateDefaultStreamWrongLocation() throws Exception {
+    TableSchema tableSchema =
+        TableSchema.newBuilder().addFields(0, TEST_INT).addFields(1, TEST_STRING).build();
+    testBigQueryWrite.addResponse(
+        WriteStream.newBuilder()
+            .setName(TEST_STREAM)
+            .setLocation("aa")
+            .setTableSchema(tableSchema)
+            .build());
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() throws Throwable {
+                JsonStreamWriter.newBuilder(TEST_TABLE, client)
+                    .setChannelProvider(channelProvider)
+                    .setCredentialsProvider(NoCredentialsProvider.create())
+                    .setLocation("bb")
+                    .build();
+              }
+            });
+    assertEquals("Specified location bb does not match the system value aa", ex.getMessage());
+  }
+
+  @Test
   public void testSimpleSchemaUpdate() throws Exception {
     try (JsonStreamWriter writer =
         getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {


### PR DESCRIPTION
This PR is about if JsonStreamWriter already calls GetWriteStream to figure out the table's schema (should be what most users will use in the future), also populate location info from the result so that later on, we don't need to look up the location info again. Also added location accessor on StreamWriter and JsonStreamWriter.
