### PR TITLE
fix: remove the client lib header setting since after router migration, it is no longer needed

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -77,7 +77,11 @@ public class JsonStreamWriter implements AutoCloseable {
     this.descriptor =
         BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(builder.tableSchema);
 
-    streamWriterBuilder = StreamWriter.newBuilder(builder.streamName);
+    if (builder.client == null) {
+      streamWriterBuilder = StreamWriter.newBuilder(builder.streamName);
+    } else {
+      streamWriterBuilder = StreamWriter.newBuilder(builder.streamName, builder.client);
+    }
     this.protoSchema = ProtoSchemaConverter.convert(this.descriptor);
     this.totalMessageSize = protoSchema.getSerializedSize();
     this.client = builder.client;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -276,10 +276,6 @@ public class StreamWriter implements AutoCloseable {
               .setCredentialsProvider(builder.credentialsProvider)
               .setTransportChannelProvider(builder.channelProvider)
               .setEndpoint(builder.endpoint)
-              // (b/185842996): Temporily fix this by explicitly providing the header.
-              .setHeaderProvider(
-                  FixedHeaderProvider.create(
-                      "x-goog-request-params", "write_stream=" + this.streamName))
               .build();
       testOnlyClientCreatedTimes++;
       return BigQueryWriteClient.create(stubSettings);
@@ -392,9 +388,7 @@ public class StreamWriter implements AutoCloseable {
   }
 
   /**
-   * Constructs a new {@link StreamWriterV2.Builder} using the given stream and client. AppendRows
-   * needs special headers to be added to client, so a passed in client will not work. This should
-   * be used by test only.
+   * Constructs a new {@link StreamWriterV2.Builder} using the given stream and client.
    */
   public static StreamWriter.Builder newBuilder(String streamName, BigQueryWriteClient client) {
     return new StreamWriter.Builder(streamName, client);

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -19,7 +19,6 @@ import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
-import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auto.value.AutoOneOf;
 import com.google.auto.value.AutoValue;
@@ -387,9 +386,7 @@ public class StreamWriter implements AutoCloseable {
     singleConnectionOrConnectionPool.close(this);
   }
 
-  /**
-   * Constructs a new {@link StreamWriterV2.Builder} using the given stream and client.
-   */
+  /** Constructs a new {@link StreamWriterV2.Builder} using the given stream and client. */
   public static StreamWriter.Builder newBuilder(String streamName, BigQueryWriteClient client) {
     return new StreamWriter.Builder(streamName, client);
   }


### PR DESCRIPTION
We have e2e test coverage here:
https://github.com/googleapis/java-bigquerystorage/blob/main/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java#L220
