### PR TITLE
chore: remove duplicate protobuf-java dependency

### DIFF
--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -206,10 +206,6 @@
       <artifactId>google-cloud-core</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
This could be the cause of frequent kokoro check failures.
