### PR TITLE
Some refactoring ideas for Storage client library

### DIFF
--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -310,10 +310,10 @@ public class StreamWriterTest {
             .setWriteStream(TEST_STREAM_1)
             .build());
 
-    assertEquals(writer.getUpdatedSchema(), null);
+    assertEquals(null, writer.getUpdatedSchema());
     AppendRowsResponse response =
         writer.append(createProtoRows(new String[] {String.valueOf(0)}), 0).get();
-    assertEquals(writer.getUpdatedSchema(), UPDATED_TABLE_SCHEMA);
+    assertEquals(UPDATED_TABLE_SCHEMA, writer.getUpdatedSchema());
 
     // Create another writer, although it's the same stream name but the time stamp is newer, thus
     // the old updated schema won't get returned.
@@ -325,7 +325,7 @@ public class StreamWriterTest {
             .setEnableConnectionPool(enableMultiplexing)
             .setLocation("us")
             .build();
-    assertEquals(writer2.getUpdatedSchema(), null);
+    assertEquals(null, writer2.getUpdatedSchema());
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.protobuf-java.version>3.14.0</project.protobuf-java.version>
+    <project.protobuf-java.version>3.18.3</project.protobuf-java.version>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-bigquerystorage-parent</site.installationModule>
   </properties>


### PR DESCRIPTION
Remove streamWriterToConnection and connectionToWriteStream maps, and instead store this data in the StreamWriter and ConnectionWorker objects themselves. This means that we no longer have to do a map lookup on every call to append().

Instead of using timestamps to determine which StreamWriter objects to send updated schema to, use a registration method. This way only StreamWriters that were created prior to a schema-update callback will get the updated schema (Note: this uses a static map, but could instead be done by updating the StreamWriter directly). I think this preserves the intended semantics from before, but needs a good look. Note: the timestamp approach isn't guaranteed to work, since it's possible for the time to stay the same between StreamWriter creation and the callback (Java does not guarantee that System.nanoTime() actually updates every nanosecond - it provides no guarantee on update frequency).

Some other things worth experimenting with in the future:
   - See if we can remove the global lock in ConnectionWorkerPool and instead use local locks in StreamWriter and ConnectionWorker. This might reduce lock contention, but will cause us to always grab two locks instead of 1 which might use more CPU. Unclear which approach is better.
   -  Right now ConnectionWorkerPool always checks isOverwhelmed on every call to append and looks for a new stream in that case. If we're in a case where all streams are at their maximum, this might cause a lot of extra CPU usage at the time we can least afford it (when the worker is already overwhelmed!). We should consider throttling this - e.g. maybe we only move a StreamWriter to a new stream if it's been > 1 sec since the last time we checked.
   - As mentioned above, there are other ways of dealing with updatedSchema.

