### PR TITLE
fix: improve ConnectionWorker fine logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.5.0')
+implementation platform('com.google.cloud:libraries-bom:26.6.0')
 
 implementation 'com.google.cloud:google-cloud-bigquerystorage'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.28.4'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.29.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.28.4"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.29.0"
 ```
 
 ## Authentication


### PR DESCRIPTION
1. Add unique worker id.
2. Remove per request and per response logging.
