### PR TITLE
feat: Add userClose flag back to StreamWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.5.0')
+implementation platform('com.google.cloud:libraries-bom:26.6.0')
 
 implementation 'com.google.cloud:google-cloud-bigquerystorage'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.28.4'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.29.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.28.4"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.29.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -273,7 +273,7 @@ class ConnectionWorker implements AutoCloseable {
     return appendInternal(requestBuilder.build());
   }
 
-  Boolean isClosed() {
+  Boolean isUserClosed() {
     this.lock.lock();
     try {
       return userClosed;
@@ -387,8 +387,13 @@ class ConnectionWorker implements AutoCloseable {
   }
 
   boolean isConnectionInUnrecoverableState() {
-    // If final status is set, there's no
-    return connectionFinalStatus != null;
+    this.lock.lock();
+    try {
+      // If final status is set, there's no
+      return connectionFinalStatus != null;
+    } finally {
+      this.lock.unlock();
+    }
   }
 
   /** Close the stream writer. Shut down all resources. */
@@ -802,7 +807,7 @@ class ConnectionWorker implements AutoCloseable {
   }
 
   // Class that wraps AppendRowsRequest and its corresponding Response future.
-  private static final class AppendRequestAndResponse {
+  static final class AppendRequestAndResponse {
     final SettableApiFuture<AppendRowsResponse> appendResult;
     final AppendRowsRequest message;
     final long messageSize;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -273,6 +273,15 @@ class ConnectionWorker implements AutoCloseable {
     return appendInternal(requestBuilder.build());
   }
 
+  Boolean isClosed() {
+    this.lock.lock();
+    try {
+      return userClosed;
+    } finally {
+      this.lock.unlock();
+    }
+  }
+
   private ApiFuture<AppendRowsResponse> appendInternal(AppendRowsRequest message) {
     AppendRequestAndResponse requestWrapper = new AppendRequestAndResponse(message);
     if (requestWrapper.messageSize > getApiMaxRequestBytes()) {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
@@ -379,7 +379,7 @@ public class ConnectionWorkerPool {
     connectionWorkerPool.add(connectionWorker);
     log.info(
         String.format(
-            "Scaling up new connection for stream name: %s, pool size after scaling up %s",
+            "Scaling up new connection for stream name: %s, pool size after scaling up %d",
             streamName, connectionWorkerPool.size()));
     return connectionWorker;
   }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoOneOf;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.bigquery.storage.v1.ConnectionWorker.AppendRequestAndResponse;
 import com.google.cloud.bigquery.storage.v1.ConnectionWorker.TableSchemaAndTimestamp;
+import com.google.cloud.bigquery.storage.v1.Exceptions.StreamWriterClosedException;
 import com.google.cloud.bigquery.storage.v1.StreamWriter.SingleConnectionOrConnectionPool.Kind;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -378,9 +379,11 @@ public class StreamWriter implements AutoCloseable {
       AppendRequestAndResponse requestWrapper =
           new AppendRequestAndResponse(AppendRowsRequest.newBuilder().build());
       requestWrapper.appendResult.setException(
-          new StatusRuntimeException(
-              Status.fromCode(Code.FAILED_PRECONDITION)
-                  .withDescription("User slosed StreamWriter")));
+          new Exceptions.StreamWriterClosedException(
+              Status.fromCode(Status.Code.FAILED_PRECONDITION)
+                  .withDescription("User closed StreamWriter"),
+              streamName,
+              getWriterId()));
       return requestWrapper.appendResult;
     }
     return this.singleConnectionOrConnectionPool.append(this, rows, offset);

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -24,7 +24,6 @@ import com.google.auto.value.AutoOneOf;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.bigquery.storage.v1.ConnectionWorker.AppendRequestAndResponse;
 import com.google.cloud.bigquery.storage.v1.ConnectionWorker.TableSchemaAndTimestamp;
-import com.google.cloud.bigquery.storage.v1.Exceptions.StreamWriterClosedException;
 import com.google.cloud.bigquery.storage.v1.StreamWriter.SingleConnectionOrConnectionPool.Kind;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -380,7 +380,7 @@ public class StreamWriter implements AutoCloseable {
       requestWrapper.appendResult.setException(
           new StatusRuntimeException(
               Status.fromCode(Code.FAILED_PRECONDITION)
-                  .withDescription("User Closed streamWriter")));
+                  .withDescription("User slosed StreamWriter")));
       return requestWrapper.appendResult;
     }
     return this.singleConnectionOrConnectionPool.append(this, rows, offset);

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -77,7 +77,7 @@ public class StreamWriter implements AutoCloseable {
   /*
    * If user has closed the StreamWriter.
    */
-  private AtomicBoolean userClosed;
+  private AtomicBoolean userClosed = new AtomicBoolean(false);
 
   /*
    * A String that uniquely identifies this writer.
@@ -153,7 +153,6 @@ public class StreamWriter implements AutoCloseable {
     }
 
     public void close(StreamWriter streamWriter) {
-      this.userClosed.set(true);
       if (getKind() == Kind.CONNECTION_WORKER) {
         connectionWorker().close();
       } else {
@@ -424,7 +423,7 @@ public class StreamWriter implements AutoCloseable {
    *     StreamWriter is explicitly closed or the underlying connection is broken when connection
    *     pool is not used. Client should recreate StreamWriter in this case.
    */
-  public Boolean isDone() {
+  public boolean isDone() {
     if (singleConnectionOrConnectionPool.getKind() == Kind.CONNECTION_WORKER) {
       return userClosed.get()
           || singleConnectionOrConnectionPool.connectionWorker().isConnectionInUnrecoverableState();
@@ -437,6 +436,7 @@ public class StreamWriter implements AutoCloseable {
   /** Close the stream writer. Shut down all resources. */
   @Override
   public void close() {
+    userClosed.set(true);
     singleConnectionOrConnectionPool.close(this);
   }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/FakeBigQueryWrite.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/FakeBigQueryWrite.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery.storage.v1;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.protobuf.AbstractMessage;
 import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -101,5 +102,9 @@ public class FakeBigQueryWrite implements MockGrpcService {
 
   public void setExecutor(ScheduledExecutorService executor) {
     serviceImpl.setExecutor(executor);
+  }
+
+  public void setFailedStatus(Status failedStatus) {
+    serviceImpl.setFailedStatus(failedStatus);
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -1284,11 +1284,12 @@ public class StreamWriterTest {
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     appendFuture1.get();
     ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"A"});
-    ExecutionException ex = assertThrows(
-        ExecutionException.class,
-        () -> {
-          appendFuture2.get();
-        });
+    ExecutionException ex =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              appendFuture2.get();
+            });
     assertTrue(ex.getCause() instanceof InvalidArgumentException);
     assertFalse(writer.isDone());
   }
@@ -1304,11 +1305,12 @@ public class StreamWriterTest {
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     appendFuture1.get();
     ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"A"});
-    ExecutionException ex = assertThrows(
-        ExecutionException.class,
-        () -> {
-          appendFuture2.get();
-        });
+    ExecutionException ex =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              appendFuture2.get();
+            });
     assertTrue(writer.isDone());
     assertTrue(ex.getCause() instanceof InvalidArgumentException);
   }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -1038,7 +1038,7 @@ public class StreamWriterTest {
     // The basic StatusRuntimeException API is not changed.
     assertTrue(actualError instanceof StatusRuntimeException);
     assertEquals(Status.Code.FAILED_PRECONDITION, actualError.getStatus().getCode());
-    assertTrue(actualError.getStatus().getDescription().contains("Connection is already closed"));
+    assertTrue(actualError.getStatus().getDescription().contains("User closed StreamWriter"));
     assertEquals(actualError.getWriterId(), writer.getWriterId());
     assertEquals(actualError.getStreamName(), writer.getStreamName());
   }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -1230,7 +1230,7 @@ public class StreamWriterTest {
   @Test(timeout = 10000)
   public void testStreamWriterUserCloseMultiplexing() throws Exception {
     StreamWriter writer =
-        StreamWriter.newBuilder(TEST_STREAM_1)
+        StreamWriter.newBuilder(TEST_STREAM_1, client)
             .setWriterSchema(createProtoSchema())
             .setEnableConnectionPool(true)
             .setLocation("us")
@@ -1253,7 +1253,7 @@ public class StreamWriterTest {
   @Test(timeout = 10000)
   public void testStreamWriterUserCloseNoMultiplexing() throws Exception {
     StreamWriter writer =
-        StreamWriter.newBuilder(TEST_STREAM_1).setWriterSchema(createProtoSchema()).build();
+        StreamWriter.newBuilder(TEST_STREAM_1, client).setWriterSchema(createProtoSchema()).build();
 
     writer.close();
     assertTrue(writer.isDone());

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -54,6 +54,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
 import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Assert;
@@ -100,6 +101,7 @@ public class StreamWriterTest {
       ProtoSchemaConverter.convert(
           BQTableSchemaToProtoDescriptor.convertBQTableSchemaToProtoDescriptor(
               UPDATED_TABLE_SCHEMA));
+  private Lock lock;
 
   public StreamWriterTest() throws DescriptorValidationException {}
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -30,6 +30,7 @@ import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.api.gax.rpc.AbortedException;
 import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.UnknownException;
 import com.google.cloud.bigquery.storage.test.Test.FooType;
@@ -1283,11 +1284,12 @@ public class StreamWriterTest {
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     appendFuture1.get();
     ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"A"});
-    assertThrows(
+    ExecutionException ex = assertThrows(
         ExecutionException.class,
         () -> {
           appendFuture2.get();
         });
+    assertTrue(ex.getCause() instanceof InvalidArgumentException);
     assertFalse(writer.isDone());
   }
 
@@ -1302,11 +1304,12 @@ public class StreamWriterTest {
     ApiFuture<AppendRowsResponse> appendFuture1 = sendTestMessage(writer, new String[] {"A"});
     appendFuture1.get();
     ApiFuture<AppendRowsResponse> appendFuture2 = sendTestMessage(writer, new String[] {"A"});
-    assertThrows(
+    ExecutionException ex = assertThrows(
         ExecutionException.class,
         () -> {
           appendFuture2.get();
         });
     assertTrue(writer.isDone());
+    assertTrue(ex.getCause() instanceof InvalidArgumentException);
   }
 }


### PR DESCRIPTION
Currently if StreamWriter is closed, in multiplexing mode, there is nothing to guard against append to happen again.

We still need StreamWriter has a closed state and we also need to tie it to all the StreamWriter's inflight request queue. I think we need to move back some of the "contractural" StreamWriter test case instead of moving them all down to ConnectionWorker.
