### PR TITLE
chore: add comment to clarify behavior setExecutorProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.6.0')
+implementation platform('com.google.cloud:libraries-bom:26.7.0')
 
 implementation 'com.google.cloud:google-cloud-bigquerystorage'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.30.0'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.31.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.30.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.31.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -487,6 +487,10 @@ public class JsonStreamWriter implements AutoCloseable {
     /**
      * Setter for the underlying StreamWriter's ExecutorProvider.
      *
+     * <p>Note that if a BigQueryWriteClient object is provided when calling newBuilder, the
+     * provider passed in to setExecutorProvider will not be used by streamWriter; the
+     * ExecutorProvider provided to the BigQueryWriteClient object will be used instead.
+     *
      * @param executorProvider
      * @return
      */


### PR DESCRIPTION
When creating a JsonStreamWriter builder, if the provided BigQueryWriteClient is not null, then any ExecutorProvider added by setExecutorProvider will not be used.  This is reasonable default behavior, but is not obvious.
