### PR TITLE
feat: Add header back to the client

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -513,7 +513,7 @@ class ConnectionWorker implements AutoCloseable {
    *
    * It takes requests from waiting queue and sends them to server.
    */
-  private void appendLoop() {
+  private void appendLoop() throws IOException {
     Deque<AppendRequestAndResponse> localQueue = new LinkedList<AppendRequestAndResponse>();
     boolean streamNeedsConnecting = false;
 
@@ -570,7 +570,7 @@ class ConnectionWorker implements AutoCloseable {
           newHeaders.putAll(clientSettings.toBuilder().getHeaderProvider().getHeaders());
           newHeaders.put(
               "x-goog-request-params",
-              "write_stream=" + localQueue.pollFirst().message.getWriteStream());
+              "write_stream=" + localQueue.peekFirst().message.getWriteStream());
           BigQueryWriteSettings stubSettings =
               clientSettings
                   .toBuilder()

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -210,8 +210,6 @@ class ConnectionWorker implements AutoCloseable {
   private RuntimeException testOnlyRunTimeExceptionInAppendLoop = null;
   private long testOnlyAppendLoopSleepTime = 0;
 
-  private BigQueryWriteSettings clientSettings = null;
-
   /** The maximum size of one request. Defined by the API. */
   public static long getApiMaxRequestBytes() {
     return 10L * 1000L * 1000L; // 10 megabytes (https://en.wikipedia.org/wiki/Megabyte)

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -241,7 +241,10 @@ class ConnectionWorker implements AutoCloseable {
     newHeaders.putAll(clientSettings.toBuilder().getHeaderProvider().getHeaders());
     newHeaders.put("x-goog-request-params", "write_stream=" + streamName);
     BigQueryWriteSettings stubSettings =
-        clientSettings.toBuilder().setHeaderProvider(FixedHeaderProvider.create(newHeaders)).build();
+        clientSettings
+            .toBuilder()
+            .setHeaderProvider(FixedHeaderProvider.create(newHeaders))
+            .build();
     this.client = BigQueryWriteClient.create(stubSettings);
 
     this.appendThread =

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -320,7 +320,6 @@ class ConnectionWorker implements AutoCloseable {
   /** Schedules the writing of rows at given offset. */
   ApiFuture<AppendRowsResponse> append(StreamWriter streamWriter, ProtoRows rows, long offset) {
     if (this.location != null && this.location != streamWriter.getLocation()) {
-      log.info("111111");
       throw new StatusRuntimeException(
           Status.fromCode(Code.INVALID_ARGUMENT)
               .withDescription(
@@ -329,7 +328,6 @@ class ConnectionWorker implements AutoCloseable {
                       + " is scheduled to use a connection with location "
                       + this.location));
     } else if (this.location == null && streamWriter.getStreamName() != this.streamName) {
-      log.info("2222222");
       throw new StatusRuntimeException(
           Status.fromCode(Code.INVALID_ARGUMENT)
               .withDescription(

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -328,6 +328,7 @@ class ConnectionWorker implements AutoCloseable {
                       + " is scheduled to use a connection with location "
                       + this.location));
     } else if (this.location == null && streamWriter.getStreamName() != this.streamName) {
+      // Location is null implies this is non-multiplexed connection.
       throw new StatusRuntimeException(
           Status.fromCode(Code.INVALID_ARGUMENT)
               .withDescription(

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
@@ -288,7 +288,7 @@ public class ConnectionWorkerPool {
     String streamReference = streamWriter.getStreamName();
     if (connectionWorkerPool.size() < currentMaxConnectionCount) {
       // Always create a new connection if we haven't reached current maximum.
-      return createConnectionWorker(streamWriter.getStreamName(), streamWriter.getProtoSchema());
+      return createConnectionWorker(streamWriter.getStreamName(), streamWriter.getLocation(), streamWriter.getProtoSchema());
     } else {
       ConnectionWorker existingBestConnection =
           pickBestLoadConnection(
@@ -304,7 +304,7 @@ public class ConnectionWorkerPool {
         if (currentMaxConnectionCount > settings.maxConnectionsPerRegion()) {
           currentMaxConnectionCount = settings.maxConnectionsPerRegion();
         }
-        return createConnectionWorker(streamWriter.getStreamName(), streamWriter.getProtoSchema());
+        return createConnectionWorker(streamWriter.getStreamName(), streamWriter.getLocation(), streamWriter.getProtoSchema());
       } else {
         // Stick to the original connection if all the connections are overwhelmed.
         if (existingConnectionWorker != null) {
@@ -359,7 +359,7 @@ public class ConnectionWorkerPool {
    * a single stream reference. This is because createConnectionWorker(...) is called via
    * computeIfAbsent(...) which is at most once per key.
    */
-  private ConnectionWorker createConnectionWorker(String streamName, ProtoSchema writeSchema)
+  private ConnectionWorker createConnectionWorker(String streamName, String location, ProtoSchema writeSchema)
       throws IOException {
     if (enableTesting) {
       // Though atomic integer is super lightweight, add extra if check in case adding future logic.
@@ -368,6 +368,7 @@ public class ConnectionWorkerPool {
     ConnectionWorker connectionWorker =
         new ConnectionWorker(
             streamName,
+            location,
             writeSchema,
             maxInflightRequests,
             maxInflightBytes,

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
@@ -288,7 +288,8 @@ public class ConnectionWorkerPool {
     String streamReference = streamWriter.getStreamName();
     if (connectionWorkerPool.size() < currentMaxConnectionCount) {
       // Always create a new connection if we haven't reached current maximum.
-      return createConnectionWorker(streamWriter.getStreamName(), streamWriter.getLocation(), streamWriter.getProtoSchema());
+      return createConnectionWorker(
+          streamWriter.getStreamName(), streamWriter.getLocation(), streamWriter.getProtoSchema());
     } else {
       ConnectionWorker existingBestConnection =
           pickBestLoadConnection(
@@ -304,7 +305,10 @@ public class ConnectionWorkerPool {
         if (currentMaxConnectionCount > settings.maxConnectionsPerRegion()) {
           currentMaxConnectionCount = settings.maxConnectionsPerRegion();
         }
-        return createConnectionWorker(streamWriter.getStreamName(), streamWriter.getLocation(), streamWriter.getProtoSchema());
+        return createConnectionWorker(
+            streamWriter.getStreamName(),
+            streamWriter.getLocation(),
+            streamWriter.getProtoSchema());
       } else {
         // Stick to the original connection if all the connections are overwhelmed.
         if (existingConnectionWorker != null) {
@@ -359,8 +363,8 @@ public class ConnectionWorkerPool {
    * a single stream reference. This is because createConnectionWorker(...) is called via
    * computeIfAbsent(...) which is at most once per key.
    */
-  private ConnectionWorker createConnectionWorker(String streamName, String location, ProtoSchema writeSchema)
-      throws IOException {
+  private ConnectionWorker createConnectionWorker(
+      String streamName, String location, ProtoSchema writeSchema) throws IOException {
     if (enableTesting) {
       // Though atomic integer is super lightweight, add extra if check in case adding future logic.
       testValueCreateConnectionCount.getAndIncrement();

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -208,6 +208,7 @@ public class StreamWriter implements AutoCloseable {
           SingleConnectionOrConnectionPool.ofSingleConnection(
               new ConnectionWorker(
                   builder.streamName,
+                  builder.location,
                   builder.writerSchema,
                   builder.maxInflightRequest,
                   builder.maxInflightBytes,

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPoolTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPoolTest.java
@@ -430,6 +430,7 @@ public class ConnectionWorkerPoolTest {
     return StreamWriter.newBuilder(streamName)
         .setWriterSchema(createProtoSchema())
         .setTraceId(TEST_TRACE_ID)
+        .setLocation("us")
         .setCredentialsProvider(NoCredentialsProvider.create())
         .setChannelProvider(serviceHelper.createChannelProvider())
         .build();

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerTest.java
@@ -86,10 +86,12 @@ public class ConnectionWorkerTest {
       StreamWriter sw1 =
           StreamWriter.newBuilder(TEST_STREAM_1, client)
               .setWriterSchema(createProtoSchema("foo"))
+              .setLocation("us")
               .build();
       StreamWriter sw2 =
           StreamWriter.newBuilder(TEST_STREAM_2, client)
               .setWriterSchema(createProtoSchema("complicate"))
+              .setLocation("us")
               .build();
       // We do a pattern of:
       // send to stream1, string1
@@ -207,11 +209,20 @@ public class ConnectionWorkerTest {
       // send to stream1, schema1
       // ...
       StreamWriter sw1 =
-          StreamWriter.newBuilder(TEST_STREAM_1, client).setWriterSchema(schema1).build();
+          StreamWriter.newBuilder(TEST_STREAM_1, client)
+              .setLocation("us")
+              .setWriterSchema(schema1)
+              .build();
       StreamWriter sw2 =
-          StreamWriter.newBuilder(TEST_STREAM_1, client).setWriterSchema(schema2).build();
+          StreamWriter.newBuilder(TEST_STREAM_1, client)
+              .setLocation("us")
+              .setWriterSchema(schema2)
+              .build();
       StreamWriter sw3 =
-          StreamWriter.newBuilder(TEST_STREAM_1, client).setWriterSchema(schema3).build();
+          StreamWriter.newBuilder(TEST_STREAM_1, client)
+              .setLocation("us")
+              .setWriterSchema(schema3)
+              .build();
       for (long i = 0; i < appendCount; i++) {
         switch ((int) i % 4) {
           case 0:
@@ -307,7 +318,10 @@ public class ConnectionWorkerTest {
   public void testAppendButInflightQueueFull() throws Exception {
     ProtoSchema schema1 = createProtoSchema("foo");
     StreamWriter sw1 =
-        StreamWriter.newBuilder(TEST_STREAM_1, client).setWriterSchema(schema1).build();
+        StreamWriter.newBuilder(TEST_STREAM_1, client)
+            .setLocation("us")
+            .setWriterSchema(schema1)
+            .build();
     ConnectionWorker connectionWorker =
         new ConnectionWorker(
             TEST_STREAM_1,
@@ -359,7 +373,10 @@ public class ConnectionWorkerTest {
   public void testThrowExceptionWhileWithinAppendLoop() throws Exception {
     ProtoSchema schema1 = createProtoSchema("foo");
     StreamWriter sw1 =
-        StreamWriter.newBuilder(TEST_STREAM_1, client).setWriterSchema(schema1).build();
+        StreamWriter.newBuilder(TEST_STREAM_1, client)
+            .setLocation("us")
+            .setWriterSchema(schema1)
+            .build();
     ConnectionWorker connectionWorker =
         new ConnectionWorker(
             TEST_STREAM_1,


### PR DESCRIPTION
Write API is going to use GFE dynamic routing instead of global router. Once that is migrated, header is needed for routing decisions.
