### PR TITLE
fix: correct AppendSerializtionError typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.33.1'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.34.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.33.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.34.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -21,7 +21,7 @@ import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.bigquery.storage.v1.AppendRowsRequest.ProtoData;
-import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.StreamConnection.DoneCallback;
 import com.google.cloud.bigquery.storage.v1.StreamConnection.RequestCallback;
 import com.google.common.annotations.VisibleForTesting;
@@ -901,8 +901,8 @@ class ConnectionWorker implements AutoCloseable {
                 rowIndexToErrorMessage.put(
                     Math.toIntExact(rowError.getIndex()), rowError.getMessage());
               }
-              AppendSerializtionError exception =
-                  new AppendSerializtionError(
+              AppendSerializationError exception =
+                  new AppendSerializationError(
                       response.getError().getCode(),
                       response.getError().getMessage(),
                       streamName,

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
@@ -244,6 +244,14 @@ public final class Exceptions {
     }
   }
 
+  public static class AppendSerializationError extends AppendSerializtionError{
+
+    public AppendSerializationError(int codeValue, String description, String streamName,
+        Map<Integer, String> rowIndexToErrorMessage) {
+      super(codeValue, description, streamName, rowIndexToErrorMessage);
+    }
+  }
+
   /** This exception is used internally to handle field level parsing errors. */
   public static class FieldParseError extends IllegalArgumentException {
     private final String fieldName;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
@@ -244,9 +244,12 @@ public final class Exceptions {
     }
   }
 
-  public static class AppendSerializationError extends AppendSerializtionError{
+  public static class AppendSerializationError extends AppendSerializtionError {
 
-    public AppendSerializationError(int codeValue, String description, String streamName,
+    public AppendSerializationError(
+        int codeValue,
+        String description,
+        String streamName,
         Map<Integer, String> rowIndexToErrorMessage) {
       super(codeValue, description, streamName, rowIndexToErrorMessage);
     }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
@@ -216,8 +216,8 @@ public final class Exceptions {
   }
 
   /**
-   * This class has a typo in the name. It will be removed soon.
-   * Please use {@link AppendSerializationError}
+   * This class has a typo in the name. It will be removed soon. Please use {@link
+   * AppendSerializationError}
    */
   public static class AppendSerializtionError extends StatusRuntimeException {
     private final Map<Integer, String> rowIndexToErrorMessage;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Exceptions.java
@@ -216,10 +216,8 @@ public final class Exceptions {
   }
 
   /**
-   * This exception is thrown from {@link JsonStreamWriter#append()} when the client side Json to
-   * Proto serializtion fails. It can also be thrown by the server in case rows contains invalid
-   * data. The exception contains a Map of indexes of faulty rows and the corresponding error
-   * message.
+   * This class has a typo in the name. It will be removed soon.
+   * Please use {@link AppendSerializationError}
    */
   public static class AppendSerializtionError extends StatusRuntimeException {
     private final Map<Integer, String> rowIndexToErrorMessage;
@@ -244,6 +242,12 @@ public final class Exceptions {
     }
   }
 
+  /**
+   * This exception is thrown from {@link JsonStreamWriter#append()} when the client side Json to
+   * Proto serializtion fails. It can also be thrown by the server in case rows contains invalid
+   * data. The exception contains a Map of indexes of faulty rows and the corresponding error
+   * message.
+   */
   public static class AppendSerializationError extends AppendSerializtionError {
 
     public AppendSerializationError(

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -194,7 +194,8 @@ public class JsonStreamWriter implements AutoCloseable {
       // Any error in convertJsonToProtoMessage will throw an
       // IllegalArgumentException/IllegalStateException/NullPointerException.
       // IllegalArgumentException will be collected into a Map of row indexes to error messages.
-      // After the conversion is finished an AppendSerializationError exception that contains all the
+      // After the conversion is finished an AppendSerializationError exception that contains all
+      // the
       // conversion errors will be thrown.
       long currentRequestSize = 0;
       Map<Integer, String> rowIndexToErrorMessage = new HashMap<>();

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -20,7 +20,7 @@ import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -194,7 +194,7 @@ public class JsonStreamWriter implements AutoCloseable {
       // Any error in convertJsonToProtoMessage will throw an
       // IllegalArgumentException/IllegalStateException/NullPointerException.
       // IllegalArgumentException will be collected into a Map of row indexes to error messages.
-      // After the conversion is finished an AppendSerializtionError exception that contains all the
+      // After the conversion is finished an AppendSerializationError exception that contains all the
       // conversion errors will be thrown.
       long currentRequestSize = 0;
       Map<Integer, String> rowIndexToErrorMessage = new HashMap<>();
@@ -224,7 +224,7 @@ public class JsonStreamWriter implements AutoCloseable {
       }
 
       if (!rowIndexToErrorMessage.isEmpty()) {
-        throw new AppendSerializtionError(
+        throw new AppendSerializationError(
             Code.INVALID_ARGUMENT.getNumber(),
             "Append serialization failed for writer: " + streamName,
             streamName,

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -36,7 +36,7 @@ import com.google.cloud.bigquery.storage.test.Test.FooType;
 import com.google.cloud.bigquery.storage.test.Test.RepetitionType;
 import com.google.cloud.bigquery.storage.test.Test.UpdatedFooType;
 import com.google.cloud.bigquery.storage.v1.ConnectionWorkerPool.Settings;
-import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.TableFieldSchema.Mode;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
@@ -1096,7 +1096,7 @@ public class JsonStreamWriterTest {
       try {
         ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
         Assert.fail("expected ExecutionException");
-      } catch (AppendSerializtionError ex) {
+      } catch (AppendSerializationError ex) {
         assertEquals(
             "JSONObject has fields unknown to BigQuery: root.test_unknown.",
             ex.getRowIndexToErrorMessage().get(1));
@@ -1188,7 +1188,7 @@ public class JsonStreamWriterTest {
   }
 
   @Test
-  public void testMultipleAppendSerializtionErrors()
+  public void testMultipleAppendSerializationErrors()
       throws DescriptorValidationException, IOException, InterruptedException {
     FooType expectedProto = FooType.newBuilder().setFoo("allen").build();
     JSONObject foo = new JSONObject();
@@ -1213,10 +1213,10 @@ public class JsonStreamWriterTest {
         getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {
       try {
         ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
-        Assert.fail("expected AppendSerializtionError");
-      } catch (AppendSerializtionError appendSerializtionError) {
+        Assert.fail("expected AppendSerializationError");
+      } catch (AppendSerializationError appendSerializationError) {
         Map<Integer, String> rowIndexToErrorMessage =
-            appendSerializtionError.getRowIndexToErrorMessage();
+            appendSerializationError.getRowIndexToErrorMessage();
         assertEquals(2, rowIndexToErrorMessage.size());
         assertEquals(
             "JSONObject has fields unknown to BigQuery: root.not_foo.",
@@ -1253,10 +1253,10 @@ public class JsonStreamWriterTest {
         getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA).build()) {
       try {
         ApiFuture<AppendRowsResponse> appendFuture = writer.append(jsonArr);
-        Assert.fail("expected AppendSerializtionError");
-      } catch (AppendSerializtionError appendSerializtionError) {
+        Assert.fail("expected AppendSerializationError");
+      } catch (AppendSerializationError appendSerializationError) {
         Map<Integer, String> rowIndexToErrorMessage =
-            appendSerializtionError.getRowIndexToErrorMessage();
+            appendSerializationError.getRowIndexToErrorMessage();
         assertEquals(1, rowIndexToErrorMessage.size());
         assertTrue(
             rowIndexToErrorMessage

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
@@ -28,7 +28,7 @@ import com.google.cloud.bigquery.*;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.storage.test.Test.*;
 import com.google.cloud.bigquery.storage.v1.*;
-import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.Exceptions.OffsetAlreadyExists;
 import com.google.cloud.bigquery.storage.v1.Exceptions.OffsetOutOfRange;
 import com.google.cloud.bigquery.storage.v1.Exceptions.SchemaMismatchedException;
@@ -372,8 +372,8 @@ public class ITBigQueryWriteManualClientTest {
     } catch (Throwable t) {
       assertTrue(t instanceof ExecutionException);
       t = t.getCause();
-      assertTrue(t instanceof AppendSerializtionError);
-      AppendSerializtionError e = (AppendSerializtionError) t;
+      assertTrue(t instanceof AppendSerializationError);
+      AppendSerializationError e = (AppendSerializationError) t;
       LOG.info("Found row errors on stream: " + e.getStreamName());
       assertEquals(
           "Field foo: STRING(10) has maximum length 10 but got a value with length 12 on field foo.",

--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
@@ -28,7 +28,7 @@ import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
 import com.google.cloud.bigquery.storage.v1.Exceptions;
-import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.Exceptions.StorageException;
 import com.google.cloud.bigquery.storage.v1.JsonStreamWriter;
 import com.google.cloud.bigquery.storage.v1.TableName;
@@ -218,8 +218,8 @@ public class WriteToDefaultStream {
           }
         }
 
-        if (throwable instanceof AppendSerializtionError) {
-          AppendSerializtionError ase = (AppendSerializtionError) throwable;
+        if (throwable instanceof AppendSerializationError) {
+          AppendSerializationError ase = (AppendSerializationError) throwable;
           Map<Integer, String> rowIndexToErrorMessage = ase.getRowIndexToErrorMessage();
           if (rowIndexToErrorMessage.size() > 0) {
             // Omit the faulty rows


### PR DESCRIPTION
Since we don't want to break customers using the `AppendSerializtionError`(with typo) and at the same time, move all the reference we have to that class in the library, to the class without typo, it made sense to use class `AppendSerializationError extends AppendSerializtionError` (super class has typo).

The other way round would mean, we move the code in `AppendSerializtionError` to `AppendSerializationError` for us to use in the library. That would break the external customers, if we don't move the code, that will cause code duplication.