### PR TITLE
sample: update WriteCommittedStream.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.33.1'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.34.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.33.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.34.0"
 ```
 
 ## Authentication

--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
@@ -117,7 +117,8 @@ public class WriteCommittedStream {
       // For more information about JsonStreamWriter, see:
       // https://googleapis.dev/java/google-cloud-bigquerystorage/latest/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.html
       streamWriter =
-          JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema(), client).build();
+          JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema(), client)
+              .build();
     }
 
     public void append(JSONArray data, long offset)

--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteCommittedStream.java
@@ -117,7 +117,7 @@ public class WriteCommittedStream {
       // For more information about JsonStreamWriter, see:
       // https://googleapis.dev/java/google-cloud-bigquerystorage/latest/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.html
       streamWriter =
-          JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema()).build();
+          JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema(), client).build();
     }
 
     public void append(JSONArray data, long offset)


### PR DESCRIPTION
Fixes #2046

This change allows streamWriter to use BiqQuery Client passed to initialize method and not creating another copy of BigQuery client.