### PR TITLE
fix: remove teh 30 minutes wait trying to refresh schema. Customers s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:2.35.0'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:2.36.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.35.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "2.36.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -220,7 +220,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquerystorage/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquerystorage.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquerystorage/2.35.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquerystorage/2.36.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -138,7 +138,7 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
       WriteStream writeStream = client.getWriteStream(writeStreamRequest);
       refreshWriter(writeStream.getTableSchema());
       return this.toProtoConverter.convertToProtoMessage(
-            this.descriptor, this.tableSchema, item, ignoreUnknownFields);
+          this.descriptor, this.tableSchema, item, ignoreUnknownFields);
     }
   }
   /**

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -44,7 +44,6 @@ import javax.annotation.Nullable;
  */
 public class SchemaAwareStreamWriter<T> implements AutoCloseable {
   private static final Logger LOG = Logger.getLogger(SchemaAwareStreamWriter.class.getName());
-  private static final long UPDATE_SCHEMA_RETRY_INTERVAL_MILLIS = 30100L;
   private final BigQueryWriteClient client;
   private final String streamName;
   private final StreamWriter.Builder streamWriterBuilder;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -126,9 +126,6 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
       return this.toProtoConverter.convertToProtoMessage(
           this.descriptor, this.tableSchema, item, ignoreUnknownFields);
     } catch (Exceptions.DataHasUnknownFieldException ex) {
-      // Backend cache for GetWriteStream schema staleness can be 30 seconds, wait a bit before
-      // trying to get the table schema to increase the chance of succeed. This is to avoid
-      // client's invalid datfa caused storm of GetWriteStream.
       LOG.warning(
           "Saw unknown field "
               + ex.getFieldName()

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -141,21 +141,8 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
               .build();
       WriteStream writeStream = client.getWriteStream(writeStreamRequest);
       refreshWriter(writeStream.getTableSchema());
-      try {
-        return this.toProtoConverter.convertToProtoMessage(
+      return this.toProtoConverter.convertToProtoMessage(
             this.descriptor, this.tableSchema, item, ignoreUnknownFields);
-      } catch (Exceptions.DataHasUnknownFieldException exex) {
-        LOG.warning(
-            "First attempt failed, waiting for 30 seconds to retry, stream: " + this.streamName);
-        Thread.sleep(UPDATE_SCHEMA_RETRY_INTERVAL_MILLIS);
-        writeStream = client.getWriteStream(writeStreamRequest);
-        // TODO(yiru): We should let TableSchema return a timestamp so that we can simply
-        //     compare the timestamp to see if the table schema is the same. If it is the
-        //     same, we don't need to go refresh the writer again.
-        refreshWriter(writeStream.getTableSchema());
-        return this.toProtoConverter.convertToProtoMessage(
-            this.descriptor, this.tableSchema, item, ignoreUnknownFields);
-      }
     }
   }
   /**

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -799,9 +799,7 @@ public class JsonStreamWriterTest {
                     .setType(TableFieldSchema.Type.STRING)
                     .setMode(Mode.NULLABLE))
             .build();
-    // GetWriteStream is called twice and got the updated schema
-    testBigQueryWrite.addResponse(
-        WriteStream.newBuilder().setName(TEST_STREAM).setTableSchema(tableSchema).build());
+    // GetWriteStream is called once and got the updated schema
     testBigQueryWrite.addResponse(
         WriteStream.newBuilder().setName(TEST_STREAM).setTableSchema(updatedSchema).build());
     testBigQueryWrite.addResponse(


### PR DESCRIPTION
…hould be ready to handle InvalidArgumentErrors, and removing the wait and retry can reduce their chance to get stuck

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
