### PR TITLE
feat: Support gRPC Compression

### DIFF
--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -169,5 +169,10 @@
     <method>com.google.protobuf.DynamicMessage convertToProtoMessage(com.google.protobuf.Descriptors$Descriptor, com.google.cloud.bigquery.storage.v1.TableSchema, java.lang.Object, boolean)</method>
     <to>com.google.protobuf.DynamicMessage convertToProtoMessage(com.google.protobuf.Descriptors$Descriptor, com.google.cloud.bigquery.storage.v1.TableSchema, java.lang.Iterable, boolean)</to>
   </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/bigquery/storage/v1/StreamConnection</className>
+    <method>StreamConnection(com.google.cloud.bigquery.storage.v1.BigQueryWriteClient, com.google.cloud.bigquery.storage.v1.StreamConnection$RequestCallback, com.google.cloud.bigquery.storage.v1.StreamConnection$DoneCallback, java.lang.String)</method>
+  </difference>
 </differences>
 

--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -169,10 +169,5 @@
     <method>com.google.protobuf.DynamicMessage convertToProtoMessage(com.google.protobuf.Descriptors$Descriptor, com.google.cloud.bigquery.storage.v1.TableSchema, java.lang.Object, boolean)</method>
     <to>com.google.protobuf.DynamicMessage convertToProtoMessage(com.google.protobuf.Descriptors$Descriptor, com.google.cloud.bigquery.storage.v1.TableSchema, java.lang.Iterable, boolean)</to>
   </difference>
-  <difference>
-    <differenceType>7004</differenceType>
-    <className>com/google/cloud/bigquery/storage/v1/StreamConnection</className>
-    <method>StreamConnection(com.google.cloud.bigquery.storage.v1.BigQueryWriteClient, com.google.cloud.bigquery.storage.v1.StreamConnection$RequestCallback, com.google.cloud.bigquery.storage.v1.StreamConnection$DoneCallback, java.lang.String)</method>
-  </difference>
 </differences>
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
@@ -41,6 +41,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /** Pool of connections to accept appends and distirbute to different connections. */
@@ -91,6 +92,10 @@ public class ConnectionWorkerPool {
    * TraceId for debugging purpose.
    */
   private final String traceId;
+  /*
+   * Sets the compression to use for the calls
+   */
+  private String compressorName;
 
   /** Used for test on the number of times createWorker is called. */
   private final AtomicInteger testValueCreateConnectionCount = new AtomicInteger(0);
@@ -199,12 +204,14 @@ public class ConnectionWorkerPool {
       java.time.Duration maxRetryDuration,
       FlowController.LimitExceededBehavior limitExceededBehavior,
       String traceId,
+      @Nullable String comperssorName,
       BigQueryWriteSettings clientSettings) {
     this.maxInflightRequests = maxInflightRequests;
     this.maxInflightBytes = maxInflightBytes;
     this.maxRetryDuration = maxRetryDuration;
     this.limitExceededBehavior = limitExceededBehavior;
     this.traceId = traceId;
+    this.compressorName = comperssorName;
     this.clientSettings = clientSettings;
     this.currentMaxConnectionCount = settings.minConnectionsPerRegion();
   }
@@ -379,6 +386,7 @@ public class ConnectionWorkerPool {
             maxRetryDuration,
             limitExceededBehavior,
             traceId,
+            compressorName,
             clientSettings);
     connectionWorkerPool.add(connectionWorker);
     log.info(

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -20,7 +20,6 @@ import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import com.google.common.base.Preconditions;
 import com.google.protobuf.Descriptors;
 import java.io.IOException;
 import java.util.Map;
@@ -344,11 +343,6 @@ public class JsonStreamWriter implements AutoCloseable {
      * @return Builder
      */
     public Builder setCompressorName(String compressorName) {
-      Preconditions.checkNotNull(compressorName);
-      Preconditions.checkArgument(
-          compressorName.equals("gzip"),
-          "Compression of type \"%s\" isn't supported, only \"gzip\" compression is supported.",
-          compressorName);
       this.schemaAwareStreamWriterBuilder.setCompressorName(compressorName);
       return this;
     }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -20,6 +20,7 @@ import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.common.base.Preconditions;
 import com.google.protobuf.Descriptors;
 import java.io.IOException;
 import java.util.Map;
@@ -333,6 +334,22 @@ public class JsonStreamWriter implements AutoCloseable {
      */
     public Builder setLocation(String location) {
       this.schemaAwareStreamWriterBuilder.setLocation(location);
+      return this;
+    }
+
+    /**
+     * Sets the compression to use for the calls. The compressor must be of type gzip.
+     *
+     * @param compressorName
+     * @return Builder
+     */
+    public Builder setCompressorName(String compressorName) {
+      Preconditions.checkNotNull(compressorName);
+      Preconditions.checkArgument(
+          compressorName.equals("gzip"),
+          "Compression of type \"%s\" isn't supported, only \"gzip\" compression is supported.",
+          compressorName);
+      this.schemaAwareStreamWriterBuilder.setCompressorName(compressorName);
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -623,11 +623,6 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
      * @return Builder
      */
     public Builder<T> setCompressorName(String compressorName) {
-      Preconditions.checkNotNull(compressorName);
-      Preconditions.checkArgument(
-          compressorName.equals("gzip"),
-          "Compression of type \"%s\" isn't supported, only gzip compression is supported",
-          compressorName);
       this.compressorName = compressorName;
       return this;
     }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -622,7 +622,6 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
           "Compression of type \"%s\" isn't supported, only gzip compression is supported",
           compressorName);
       this.compressorName = compressorName;
-      LOG.info("Yifat in SchemaAwsre Builder. Compressor = " + this.compressorName);
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamConnection.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamConnection.java
@@ -62,7 +62,7 @@ public class StreamConnection {
     if (compressorName != null) {
       apiCallContext =
           GrpcCallContext.createDefault()
-              .withCallOptions(CallOptions.DEFAULT.withCompression(compressorName /*"gzip"*/));
+              .withCallOptions(CallOptions.DEFAULT.withCompression(compressorName));
       log.info("gRPC compression is enabled with " + compressorName + " compression");
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamConnection.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamConnection.java
@@ -15,13 +15,18 @@
  */
 package com.google.cloud.bigquery.storage.v1;
 
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientStream;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.StreamController;
+import io.grpc.CallOptions;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * StreamConnection is responsible for writing requests to a GRPC bidirecional connection.
@@ -43,10 +48,23 @@ public class StreamConnection {
   private RequestCallback requestCallback;
   private DoneCallback doneCallback;
 
+  private static final Logger log = Logger.getLogger(StreamConnection.class.getName());
+
   public StreamConnection(
-      BigQueryWriteClient client, RequestCallback requestCallback, DoneCallback doneCallback) {
+      BigQueryWriteClient client,
+      RequestCallback requestCallback,
+      DoneCallback doneCallback,
+      @Nullable String compressorName) {
     this.requestCallback = requestCallback;
     this.doneCallback = doneCallback;
+
+    ApiCallContext apiCallContext = null;
+    if (compressorName != null) {
+      apiCallContext =
+          GrpcCallContext.createDefault()
+              .withCallOptions(CallOptions.DEFAULT.withCompression(compressorName /*"gzip"*/));
+      log.info("gRPC compression is enabled with " + compressorName + " compression");
+    }
 
     bidiStreamingCallable = client.appendRowsCallable();
     clientStream =
@@ -75,7 +93,8 @@ public class StreamConnection {
                         Status.fromCode(Code.CANCELLED)
                             .withDescription("Stream is closed by user.")));
               }
-            });
+            },
+            apiCallContext);
   }
 
   /**

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -215,6 +215,7 @@ public class StreamWriter implements AutoCloseable {
                   builder.maxRetryDuration,
                   builder.limitExceededBehavior,
                   builder.traceId,
+                  builder.compressorName,
                   clientSettings));
     } else {
       if (!isDefaultStream(streamName)) {
@@ -276,6 +277,7 @@ public class StreamWriter implements AutoCloseable {
                         builder.maxRetryDuration,
                         builder.limitExceededBehavior,
                         builder.traceId,
+                        builder.compressorName,
                         client.getSettings());
                   }));
       validateFetchedConnectonPool(builder);
@@ -598,6 +600,8 @@ public class StreamWriter implements AutoCloseable {
 
     private java.time.Duration maxRetryDuration = Duration.ofMinutes(5);
 
+    private String compressorName = null;
+
     private Builder(String streamName) {
       this.streamName = Preconditions.checkNotNull(streamName);
       this.client = null;
@@ -713,6 +717,16 @@ public class StreamWriter implements AutoCloseable {
      */
     public Builder setMaxRetryDuration(java.time.Duration maxRetryDuration) {
       this.maxRetryDuration = maxRetryDuration;
+      return this;
+    }
+
+    public Builder setCompressorName(String compressorName) {
+      Preconditions.checkNotNull(compressorName);
+      Preconditions.checkArgument(
+          compressorName.equals("gzip"),
+          "Compression of type \"%s\" isn't supported, only \"gzip\" compression is supported.",
+          compressorName);
+      this.compressorName = compressorName;
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPoolTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPoolTest.java
@@ -477,6 +477,7 @@ public class ConnectionWorkerPoolTest {
         maxRetryDuration,
         FlowController.LimitExceededBehavior.Block,
         TEST_TRACE_ID,
+        null,
         clientSettings);
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerTest.java
@@ -333,6 +333,7 @@ public class ConnectionWorkerTest {
             Duration.ofSeconds(100),
             FlowController.LimitExceededBehavior.Block,
             TEST_TRACE_ID,
+            null,
             client.getSettings());
     testBigQueryWrite.setResponseSleep(org.threeten.bp.Duration.ofSeconds(1));
     ConnectionWorker.setMaxInflightQueueWaitTime(500);
@@ -388,6 +389,7 @@ public class ConnectionWorkerTest {
             Duration.ofSeconds(100),
             FlowController.LimitExceededBehavior.Block,
             TEST_TRACE_ID,
+            null,
             client.getSettings());
     testBigQueryWrite.setResponseSleep(org.threeten.bp.Duration.ofSeconds(1));
     ConnectionWorker.setMaxInflightQueueWaitTime(500);
@@ -451,6 +453,7 @@ public class ConnectionWorkerTest {
             Duration.ofSeconds(100),
             FlowController.LimitExceededBehavior.Block,
             TEST_TRACE_ID,
+            null,
             client.getSettings());
     StatusRuntimeException ex =
         assertThrows(
@@ -481,6 +484,7 @@ public class ConnectionWorkerTest {
             Duration.ofSeconds(100),
             FlowController.LimitExceededBehavior.Block,
             TEST_TRACE_ID,
+            null,
             client.getSettings());
     StatusRuntimeException ex =
         assertThrows(
@@ -532,6 +536,7 @@ public class ConnectionWorkerTest {
         maxRetryDuration,
         FlowController.LimitExceededBehavior.Block,
         TEST_TRACE_ID,
+        null,
         client.getSettings());
   }
 
@@ -625,6 +630,7 @@ public class ConnectionWorkerTest {
             Duration.ofSeconds(100),
             FlowController.LimitExceededBehavior.Block,
             TEST_TRACE_ID,
+            null,
             client.getSettings());
     testBigQueryWrite.setResponseSleep(org.threeten.bp.Duration.ofSeconds(3));
 
@@ -681,6 +687,7 @@ public class ConnectionWorkerTest {
             Duration.ofSeconds(100),
             FlowController.LimitExceededBehavior.Block,
             TEST_TRACE_ID,
+            null,
             client.getSettings());
 
     long appendCount = 10;

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -1452,4 +1452,20 @@ public class JsonStreamWriterTest {
           missingValueMap);
     }
   }
+
+  @Test
+  public void testWrongCompressionType() throws Exception {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              getTestJsonStreamWriterBuilder(TEST_STREAM, TABLE_SCHEMA)
+                  .setCompressorName("not-gzip")
+                  .build();
+            });
+    assertTrue(
+        ex.getMessage()
+            .contains(
+                "Compression of type \"not-gzip\" isn't supported, only \"gzip\" compression is supported."));
+  }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -950,6 +950,20 @@ public class StreamWriterTest {
   }
 
   @Test
+  public void testWrongCompressionType() throws Exception {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              StreamWriter.newBuilder(TEST_STREAM_1, client).setCompressorName("not-gzip").build();
+            });
+    assertTrue(
+        ex.getMessage()
+            .contains(
+                "Compression of type \"not-gzip\" isn't supported, only \"gzip\" compression is supported."));
+  }
+
+  @Test
   public void testThrowExceptionWhileWithinAppendLoop_MaxWaitTimeExceed() throws Exception {
     ProtoSchema schema1 = createProtoSchema("foo");
     StreamWriter.setMaxRequestCallbackWaitTime(java.time.Duration.ofSeconds(1));


### PR DESCRIPTION
Enable gRPC compression when a compressor name is provided to JsonStreamWriter/StreamWriter.
Only `gzip` compression is supported at the moment.

Please note that while it will reduce the network usage, it will increase CPU usage. Please verify the trade off per use case.