### PR TITLE
chore: setup 2.38.x lts branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -18,3 +18,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 2.25.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 2.38.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -76,6 +76,20 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - OwlBot Post Processor
+  - pattern: 2.38.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (17)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - cla/google
+      - OwlBot Post Processor
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
enable releases

```
release-brancher create-pull-request \
  --branch-name="2.38.x" \
  --target-tag="v2.38.0" \
  --repo="googleapis/java-bigquerystorage" \
  --pull-request-title="chore: setup 2.38.x lts branch" \
  --release-type=java-backport
```