### PR TITLE
fix: remove FAILED_PRECONDITION from connection retry code

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.19.0')
+implementation platform('com.google.cloud:libraries-bom:26.20.0')
 
 implementation 'com.google.cloud:google-cloud-bigquerystorage'
 ```

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -936,7 +936,6 @@ class ConnectionWorker implements AutoCloseable {
         || status.getCode() == Code.UNAVAILABLE
         || status.getCode() == Code.CANCELLED
         || status.getCode() == Code.INTERNAL
-        || status.getCode() == Code.FAILED_PRECONDITION
         || status.getCode() == Code.DEADLINE_EXCEEDED;
   }
 


### PR DESCRIPTION
After the backend change here:
https://critique.corp.google.com/cl/483521407/depot/google3/cloud/helix/vortex/frontend/base/vortex_error_util.cc

We will filter out all random backend FAILED_PRECONDITION except for the case of multiple client trying to attach to the same exclusive stream case.

Dataflow side doesn't want this to be retried, they would prefer to just recreate the stream in case of a failure.

The algorithm of the race case is that the new one will always succeed, so in this case, it seems the old one shouldn't retry anyway (otherwise there could be more races).
