### PR TITLE
deps: bumping google-cloud-shared-config to v1.5.8

### DIFF
--- a/google-cloud-bigquerystorage-bom/pom.xml
+++ b/google-cloud-bigquerystorage-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
   </parent>
 
   <name>Google Cloud bigquerystorage BOM</name>

--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -83,7 +83,6 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
-      <version>${auto-value-annotation.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -83,6 +83,7 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
+      <version>${auto-value.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8</version>
   </parent>
 
   <developers>


### PR DESCRIPTION
Similar renovate-pr for this update -> https://github.com/googleapis/java-bigquerystorage/pull/2264 (close it once this is merge)
Error in tests:
```
Error:    The project com.google.cloud:google-cloud-bigquerystorage:2.43.0 (/home/runner/work/java-bigquerystorage/java-bigquerystorage/google-cloud-bigquerystorage/pom.xml) has 1 error
Error:      'dependencies.dependency.version' for com.google.auto.value:auto-value:jar must be a valid version but is '${auto-value-annotation.version}'. @ line 86, column 16
```

This is because "google-cloud-shared-config" **1.5.8** renamed `auto-value-annotation` to `auto-value`. 
Hence opening this pr for bumping this dependency and renaming the property in this repo. 