### PR TITLE
fix: add native image configurations for com.google.rpc classes

### DIFF
--- a/.kokoro/continuous/graalvm-native-17.cfg
+++ b/.kokoro/continuous/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
 }
 
 env_vars: {

--- a/.kokoro/continuous/graalvm-native.cfg
+++ b/.kokoro/continuous/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
 }
 
 env_vars: {

--- a/google-cloud-bigquerystorage/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-bigquerystorage/reflect-config.json
+++ b/google-cloud-bigquerystorage/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-bigquerystorage/reflect-config.json
@@ -3,5 +3,23 @@
     "name":"java.lang.Object",
     "allDeclaredFields":true,
     "queryAllDeclaredMethods":true,
-    "methods":[{"name":"<init>","parameterTypes":[] }]}
+    "methods":[{"name":"<init>","parameterTypes":[] }]},
+  {
+    "name": "com.google.rpc.RetryInfo",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
+  },
+  {
+    "name": "com.google.rpc.RetryInfo$Builder",
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredClasses": true,
+    "allPublicClasses": true
+  }
 ]


### PR DESCRIPTION
Fixes continuous tests that are failing with:
```
Caused by: java.lang.IllegalStateException: Generated message class "com.google.rpc.RetryInfo$Builder" missing method "getRetryDelay".
	at com.google.protobuf.GeneratedMessageV3.getMethodOrDie(GeneratedMessageV3.java:2014)
	at com.google.protobuf.GeneratedMessageV3.access$1000(GeneratedMessageV3.java:79)
	at com.google.protobuf.GeneratedMessageV3$FieldAccessorTable$SingularFieldAccessor$ReflectionInvoker.<init>(GeneratedMessageV3.java:2396)
	at com.google.protobuf.GeneratedMessageV3$FieldAccessorTable$SingularFieldAccessor.<init>(GeneratedMessageV3.java:2468)
	at com.google.protobuf.GeneratedMessageV3$FieldAccessorTable$SingularMessageFieldAccessor.<init>(GeneratedMessageV3.java:3155)
	at com.google.protobuf.GeneratedMessageV3$FieldAccessorTable.ensureFieldAccessorsInitialized(GeneratedMessageV3.java:2139)
	at com.google.rpc.RetryInfo.internalGetFieldAccessorTable(RetryInfo.java:68)
	at com.google.protobuf.GeneratedMessageV3.getDescriptorForType(GeneratedMessageV3.java:139)
	at io.grpc.protobuf.ProtoUtils.keyForProto(ProtoUtils.java:79)
	at com.google.cloud.bigquery.storage.util.Errors.<clinit>(Errors.java:34)
	... 34 more
Caused by: java.lang.NoSuchMethodException: com.google.rpc.RetryInfo$Builder.getRetryDelay()
	at java.base@17.0.7/java.lang.Class.checkMethod(DynamicHub.java:1038)
	at java.base@17.0.7/java.lang.Class.getMethod(DynamicHub.java:1023)
	at com.google.protobuf.GeneratedMessageV3.getMethodOrDie(GeneratedMessageV3.java:2011)
	... 43 more
``` 
