### PR TITLE
fix: fix WriteToDefaultStream example code to close the client properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:3.2.0'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:3.3.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "3.2.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "3.3.1"
 ```
 <!-- {x-version-update-end} -->
 
@@ -221,7 +221,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquerystorage/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquerystorage.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquerystorage/3.2.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquerystorage/3.3.1
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
@@ -138,6 +138,8 @@ public class WriteToDefaultStream {
 
     private static final int MAX_RECREATE_COUNT = 3;
 
+    private BigQueryWriteClient client;
+
     // Track the number of in-flight requests to wait for all responses before shutting down.
     private final Phaser inflightRequestCount = new Phaser(1);
     private final Object lock = new Object();
@@ -163,12 +165,16 @@ public class WriteToDefaultStream {
               .setMaxRetryDelay(Duration.ofMinutes(1))
               .build();
 
+      // Initialize client without settings, internally within stream writer a new client will be
+      // created with full settings.
+      client = BigQueryWriteClient.create();
+
       // Use the JSON stream writer to send records in JSON format. Specify the table name to write
       // to the default stream.
       // For more information about JsonStreamWriter, see:
       // https://googleapis.dev/java/google-cloud-bigquerystorage/latest/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.html
       streamWriter =
-          JsonStreamWriter.newBuilder(parentTable.toString(), BigQueryWriteClient.create())
+          JsonStreamWriter.newBuilder(parentTable.toString(), client)
               .setExecutorProvider(
                   FixedExecutorProvider.create(Executors.newScheduledThreadPool(100)))
               .setChannelProvider(
@@ -195,7 +201,7 @@ public class WriteToDefaultStream {
             && recreateCount.getAndIncrement() < MAX_RECREATE_COUNT) {
           streamWriter =
               JsonStreamWriter.newBuilder(
-                      streamWriter.getStreamName(), BigQueryWriteClient.create())
+                      streamWriter.getStreamName(), client)
                   .build();
           this.error = null;
         }
@@ -217,6 +223,7 @@ public class WriteToDefaultStream {
       // Wait for all in-flight requests to complete.
       inflightRequestCount.arriveAndAwaitAdvance();
 
+      client.close();
       // Close the connection to the server.
       streamWriter.close();
 

--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
@@ -199,10 +199,7 @@ public class WriteToDefaultStream {
         if (!streamWriter.isUserClosed()
             && streamWriter.isClosed()
             && recreateCount.getAndIncrement() < MAX_RECREATE_COUNT) {
-          streamWriter =
-              JsonStreamWriter.newBuilder(
-                      streamWriter.getStreamName(), client)
-                  .build();
+          streamWriter = JsonStreamWriter.newBuilder(streamWriter.getStreamName(), client).build();
           this.error = null;
         }
         // If earlier appends have failed, we need to reset before continuing.


### PR DESCRIPTION
Client being created has to be properly closed, otherwise during garbage
collection an error will be reported showing channel not shutdown


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
