### PR TITLE
feat: Add short, integer, long, boolean conversions into string

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.33.0')
+implementation platform('com.google.cloud:libraries-bom:26.34.0')
 
 implementation 'com.google.cloud:google-cloud-bigquerystorage'
 ```

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
@@ -650,7 +650,10 @@ public class JsonToProtoMessage implements ToProtoConverter<Object> {
         if (val instanceof String) {
           protoMsg.setField(fieldDescriptor, val);
           return;
-        } else if (val instanceof Short || val instanceof Integer || val instanceof Long || val instanceof Boolean) {
+        } else if (val instanceof Short
+            || val instanceof Integer
+            || val instanceof Long
+            || val instanceof Boolean) {
           protoMsg.setField(fieldDescriptor, String.valueOf(val));
           return;
         }
@@ -913,7 +916,10 @@ public class JsonToProtoMessage implements ToProtoConverter<Object> {
         case STRING:
           if (val instanceof String) {
             protoMsg.addRepeatedField(fieldDescriptor, val);
-          } else if (val instanceof Short || val instanceof Integer || val instanceof Long || val instanceof Boolean) {
+          } else if (val instanceof Short
+              || val instanceof Integer
+              || val instanceof Long
+              || val instanceof Boolean) {
             protoMsg.addRepeatedField(fieldDescriptor, String.valueOf(val));
             return;
           } else {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessage.java
@@ -650,6 +650,9 @@ public class JsonToProtoMessage implements ToProtoConverter<Object> {
         if (val instanceof String) {
           protoMsg.setField(fieldDescriptor, val);
           return;
+        } else if (val instanceof Short || val instanceof Integer || val instanceof Long || val instanceof Boolean) {
+          protoMsg.setField(fieldDescriptor, String.valueOf(val));
+          return;
         }
         break;
       case DOUBLE:
@@ -910,6 +913,9 @@ public class JsonToProtoMessage implements ToProtoConverter<Object> {
         case STRING:
           if (val instanceof String) {
             protoMsg.addRepeatedField(fieldDescriptor, val);
+          } else if (val instanceof Short || val instanceof Integer || val instanceof Long || val instanceof Boolean) {
+            protoMsg.addRepeatedField(fieldDescriptor, String.valueOf(val));
+            return;
           } else {
             throwWrongFieldType(fieldDescriptor, currentScope, index);
           }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -37,6 +37,7 @@ import com.google.cloud.bigquery.storage.v1.AppendRowsRequest.MissingValueInterp
 import com.google.cloud.bigquery.storage.v1.ConnectionWorkerPool.Settings;
 import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.TableFieldSchema.Mode;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Int64Value;
@@ -1406,8 +1407,8 @@ public class JsonStreamWriterTest {
     // put a vaild value into the field
     foo1.put("foo", "allen");
     JSONObject foo2 = new JSONObject();
-    // put a number into a string field
-    foo2.put("foo", 666);
+    // put a field which is not part of the expected schema
+    foo2.put("not_bar", "woody");
     JSONArray jsonArr = new JSONArray();
     jsonArr.put(foo);
     jsonArr.put(foo1);
@@ -1425,14 +1426,11 @@ public class JsonStreamWriterTest {
       } catch (AppendSerializationError appendSerializationError) {
         Map<Integer, String> rowIndexToErrorMessage =
             appendSerializationError.getRowIndexToErrorMessage();
-        assertEquals(2, rowIndexToErrorMessage.size());
         assertEquals(
-            "The source object has fields unknown to BigQuery: root.not_foo.",
-            rowIndexToErrorMessage.get(0));
-        assertEquals(
-            "Field root.foo failed to convert to STRING. Error: JSONObject does not have a string"
-                + " field at root.foo.",
-            rowIndexToErrorMessage.get(2));
+          ImmutableMap.of(
+                  0, "The source object has fields unknown to BigQuery: root.not_foo.",
+                  2, "The source object has fields unknown to BigQuery: root.not_bar."
+        ), rowIndexToErrorMessage);
       }
     }
   }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -1427,10 +1427,10 @@ public class JsonStreamWriterTest {
         Map<Integer, String> rowIndexToErrorMessage =
             appendSerializationError.getRowIndexToErrorMessage();
         assertEquals(
-          ImmutableMap.of(
-                  0, "The source object has fields unknown to BigQuery: root.not_foo.",
-                  2, "The source object has fields unknown to BigQuery: root.not_bar."
-        ), rowIndexToErrorMessage);
+            ImmutableMap.of(
+                0, "The source object has fields unknown to BigQuery: root.not_foo.",
+                2, "The source object has fields unknown to BigQuery: root.not_bar."),
+            rowIndexToErrorMessage);
       }
     }
   }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessageTest.java
@@ -933,7 +933,7 @@ public class JsonToProtoMessageTest {
       } else if (entry.getKey() == Int64Type.getDescriptor()
           || entry.getKey() == BytesType.getDescriptor()) {
         assertEquals(entry.getKey().getFullName(), 2, success);
-      } else if(entry.getKey() == StringType.getDescriptor()) {
+      } else if (entry.getKey() == StringType.getDescriptor()) {
         assertEquals(entry.getKey().getFullName(), 4, success);
       } else {
         assertEquals(entry.getKey().getFullName(), 1, success);
@@ -1019,14 +1019,14 @@ public class JsonToProtoMessageTest {
     }
   }
 
-    @Test
-    public void testStructSimple() throws Exception {
-        structSimple("test", "test");
-        structSimple(true, "true");
-        structSimple(1, "1");
-        structSimple((short) 1, "1");
-        structSimple((long) 1, "1");
-    }
+  @Test
+  public void testStructSimple() throws Exception {
+    structSimple("test", "test");
+    structSimple(true, "true");
+    structSimple(1, "1");
+    structSimple((short) 1, "1");
+    structSimple((long) 1, "1");
+  }
 
   private void structSimple(Object value, String expected) throws Exception {
     MessageType expectedProto =

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonToProtoMessageTest.java
@@ -87,7 +87,12 @@ public class JsonToProtoMessageTest {
               })
           .put(
               StringType.getDescriptor(),
-              new Message[] {StringType.newBuilder().setTestFieldType("test").build()})
+              new Message[] {
+                StringType.newBuilder().setTestFieldType("9223372036854775807").build(),
+                StringType.newBuilder().setTestFieldType("2147483647").build(),
+                StringType.newBuilder().setTestFieldType("true").build(),
+                StringType.newBuilder().setTestFieldType("test").build()
+              })
           .put(
               RepeatedType.getDescriptor(),
               new Message[] {
@@ -147,6 +152,9 @@ public class JsonToProtoMessageTest {
           .put(
               RepeatedString.getDescriptor(),
               new Message[] {
+                RepeatedString.newBuilder().addTestRepeated("9223372036854775807").build(),
+                RepeatedString.newBuilder().addTestRepeated("2147483647").build(),
+                RepeatedString.newBuilder().addTestRepeated("true").build(),
                 RepeatedString.newBuilder().addTestRepeated("hello").addTestRepeated("test").build()
               })
           .put(
@@ -925,6 +933,8 @@ public class JsonToProtoMessageTest {
       } else if (entry.getKey() == Int64Type.getDescriptor()
           || entry.getKey() == BytesType.getDescriptor()) {
         assertEquals(entry.getKey().getFullName(), 2, success);
+      } else if(entry.getKey() == StringType.getDescriptor()) {
+        assertEquals(entry.getKey().getFullName(), 4, success);
       } else {
         assertEquals(entry.getKey().getFullName(), 1, success);
       }
@@ -962,6 +972,8 @@ public class JsonToProtoMessageTest {
         assertEquals(entry.getKey().getFullName(), 4, success);
       } else if (entry.getKey() == RepeatedInt64.getDescriptor()) {
         assertEquals(entry.getKey().getFullName(), 2, success);
+      } else if (entry.getKey() == RepeatedString.getDescriptor()) {
+        assertEquals(entry.getKey().getFullName(), 4, success);
       } else {
         assertEquals(entry.getKey().getFullName(), 1, success);
       }
@@ -1007,16 +1019,22 @@ public class JsonToProtoMessageTest {
     }
   }
 
-  @Test
-  public void testStructSimple() throws Exception {
+    @Test
+    public void testStructSimple() throws Exception {
+        structSimple("test", "test");
+        structSimple(true, "true");
+        structSimple(1, "1");
+        structSimple((short) 1, "1");
+        structSimple((long) 1, "1");
+    }
+
+  private void structSimple(Object value, String expected) throws Exception {
     MessageType expectedProto =
         MessageType.newBuilder()
-            .setTestFieldType(StringType.newBuilder().setTestFieldType("test").build())
+            .setTestFieldType(StringType.newBuilder().setTestFieldType(expected).build())
             .build();
-    JSONObject stringType = new JSONObject();
-    stringType.put("test_field_type", "test");
-    JSONObject json = new JSONObject();
-    json.put("test_field_type", stringType);
+    JSONObject stringType = new JSONObject(ImmutableMap.of("test_field_type", value));
+    JSONObject json = new JSONObject(ImmutableMap.of("test_field_type", stringType));
 
     DynamicMessage protoMsg =
         JsonToProtoMessage.INSTANCE.convertToProtoMessage(MessageType.getDescriptor(), json);
@@ -1026,7 +1044,7 @@ public class JsonToProtoMessageTest {
   @Test
   public void testStructSimpleFail() throws Exception {
     JSONObject stringType = new JSONObject();
-    stringType.put("test_field_type", 1);
+    stringType.put("test_field_type", new boolean[0]);
     JSONObject json = new JSONObject();
     json.put("test_field_type", stringType);
     try {
@@ -1268,7 +1286,7 @@ public class JsonToProtoMessageTest {
   @Test
   public void testNestedRepeatedComplexFail() throws Exception {
     double[] doubleArr = {1.1, 2.2, 3.3, 4.4, 5.5};
-    Boolean[] fakeStringArr = {true, false};
+    Boolean[][] fakeStringArr = {new Boolean[0], new Boolean[0]};
     int[] intArr = {1, 2, 3, 4, 5};
 
     JSONObject json = new JSONObject();


### PR DESCRIPTION
We are trying to migrate from legacy streaming API but we encountered following difference when using storage api with default stream.
Using storage writer, integer value in data is NOT automatically converted to string for fields with string type in schema. Oddly enough other way around, string in data but integer in schema, automatic conversion happens when string in data value actually is number string, for example "1"

Looking into JsonToProtoMessage code, lots of conversion is performed in different cases therefore I believe simple conversion like this should be done too. 
If it is unacceptable for some reason, we can add boolean field (allowToStringConversions) to JsonStreamWriter Builder as feature flag to enable these conversion on request rather then by default

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2436☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
