### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -14,5 +14,6 @@
     "api_id": "bigquerystorage.googleapis.com",
     "transport": "grpc",
     "requires_billing": true,
-    "library_type": "GAPIC_COMBO"
+    "library_type": "GAPIC_COMBO",
+    "recommended_package": "com.google.cloud.bigquery.storage.v1"
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.36.0')
+implementation platform('com.google.cloud:libraries-bom:26.37.0')
 
 implementation 'com.google.cloud:google-cloud-bigquerystorage'
 ```


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details