### PR TITLE
feat: add instrumentation for a couple of OpenTelemetry metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-bigquerystorage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquerystorage:3.5.1'
+implementation 'com.google.cloud:google-cloud-bigquerystorage:3.5.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "3.5.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquerystorage" % "3.5.2"
 ```
 <!-- {x-version-update-end} -->
 
@@ -221,7 +221,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquerystorage/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquerystorage.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquerystorage/3.5.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquerystorage/3.5.2
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -156,6 +156,10 @@
     <artifactId>google-auth-library-credentials</artifactId>
     <version>1.23.0</version>
   </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPool.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
+import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -238,9 +239,7 @@ public class ConnectionWorkerPool {
     return append(streamWriter, rows, -1);
   }
 
-  /** Distributes the writing of a message to an underlying connection. */
-  ApiFuture<AppendRowsResponse> append(StreamWriter streamWriter, ProtoRows rows, long offset) {
-    // We are in multiplexing mode after entering the following logic.
+  ConnectionWorker getConnectionWorker(StreamWriter streamWriter) {
     ConnectionWorker connectionWorker;
     lock.lock();
     try {
@@ -277,6 +276,13 @@ public class ConnectionWorkerPool {
     } finally {
       lock.unlock();
     }
+    return connectionWorker;
+  }
+
+  /** Distributes the writing of a message to an underlying connection. */
+  ApiFuture<AppendRowsResponse> append(StreamWriter streamWriter, ProtoRows rows, long offset) {
+    // We are in multiplexing mode after entering the following logic.
+    ConnectionWorker connectionWorker = getConnectionWorker(streamWriter);
     Stopwatch stopwatch = Stopwatch.createStarted();
     ApiFuture<AppendRowsResponse> responseFuture =
         connectionWorker.append(streamWriter, rows, offset);
@@ -292,6 +298,12 @@ public class ConnectionWorkerPool {
           return response;
         },
         MoreExecutors.directExecutor());
+  }
+
+  @VisibleForTesting
+  Attributes getTelemetryAttributes(StreamWriter streamWriter) {
+    ConnectionWorker connectionWorker = getConnectionWorker(streamWriter);
+    return connectionWorker.getTelemetryAttributes();
   }
 
   /**

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Singletons.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Singletons.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.storage.v1;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import java.util.logging.Logger;
+
+/** Container for global singleton objects. */
+class Singletons {
+
+  private static final Logger log = Logger.getLogger(Singletons.class.getName());
+
+  // Global OpenTelemetry instance
+  private static OpenTelemetry openTelemetry = null;
+
+  static OpenTelemetry getOpenTelemetry() {
+    if (openTelemetry == null) {
+      openTelemetry = GlobalOpenTelemetry.get();
+    }
+    return openTelemetry;
+  }
+}

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -169,6 +170,15 @@ public class StreamWriter implements AutoCloseable {
         return connectionWorker().append(streamWriter, protoRows, offset);
       } else {
         return connectionWorkerPool().append(streamWriter, protoRows, offset);
+      }
+    }
+
+    @VisibleForTesting
+    Attributes getTelemetryAttributes(StreamWriter streamWriter) {
+      if (getKind() == Kind.CONNECTION_WORKER) {
+        return connectionWorker().getTelemetryAttributes();
+      } else {
+        return connectionWorkerPool().getTelemetryAttributes(streamWriter);
       }
     }
 
@@ -457,6 +467,11 @@ public class StreamWriter implements AutoCloseable {
       return requestWrapper.appendResult;
     }
     return this.singleConnectionOrConnectionPool.append(this, rows, offset);
+  }
+
+  @VisibleForTesting
+  Attributes getTelemetryAttributes() {
+    return this.singleConnectionOrConnectionPool.getTelemetryAttributes(this);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,13 @@
         <artifactId>json</artifactId>
         <version>20240303</version>
       </dependency>
-
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.38.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
 
       <!-- Test dependencies -->
       <dependency>


### PR DESCRIPTION
Client application is responsible for initializing OpenTelemetry to consume these metrics. If OpenTelemetry is not initialized the metrics act as a no-op.