### PR TITLE
chore: demonstrate writing a GEOGRAPHY field as string

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
+++ b/samples/snippets/src/main/java/com/example/bigquerystorage/WriteToDefaultStream.java
@@ -76,6 +76,9 @@ public class WriteToDefaultStream {
     record.put("test_string", String.format("record %03d-%03d %s", i, j, sbSuffix.toString()));
     ByteString byteString = buildByteString();
     record.put("test_bytes", byteString);
+    record.put(
+        "test_geo",
+        "POLYGON((-124.49 47.35,-124.49 40.73,-116.49 40.73,-116.49 47.35,-124.49 47.35))");
     return record;
   }
 

--- a/samples/snippets/src/test/java/com/example/bigquerystorage/WriteToDefaultStreamIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquerystorage/WriteToDefaultStreamIT.java
@@ -78,6 +78,8 @@ public class WriteToDefaultStreamIT {
                 .setMaxLength(20L)
                 .build(),
             com.google.cloud.bigquery.Field.newBuilder("test_bytes", StandardSQLTypeName.BYTES)
+                .build(),
+            com.google.cloud.bigquery.Field.newBuilder("test_geo", StandardSQLTypeName.GEOGRAPHY)
                 .build());
     bigquery.create(DatasetInfo.newBuilder(datasetName).build());
     TableInfo tableInfo =


### PR DESCRIPTION
Provide customers with a sample implementation of specifying a GEOGRAPHY table column.