### PR TITLE
chore: make the owlbot postprocessor check non-required

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,7 +15,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
       - javadoc
   - pattern: java7
     isAdminEnforced: true
@@ -46,7 +45,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
   - pattern: 2.12.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -61,7 +59,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
   - pattern: 2.25.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -76,7 +73,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
   - pattern: 2.38.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -90,7 +86,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
   - pattern: 2.47.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -104,7 +99,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
       - javadoc
 permissionRules:
   - team: yoshi-admins


### PR DESCRIPTION
We will soon disable the Owlbot postprocessor. This is part of the effort to enable hermetic generation in this repo ([context](https://docs.google.com/document/d/1wrpyBtphdenM3BNelcnpBKGADYrGJUo686HXvSA0h-0/edit?pli=1&tab=t.0#bookmark=kix.914gcjvdwt3u))