### PR TITLE
fix : using context from call in ReadRowsRetryingCallable

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/readrows/ReadRowsRetryingCallable.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/readrows/ReadRowsRetryingCallable.java
@@ -55,15 +55,16 @@ public final class ReadRowsRetryingCallable
       ReadRowsRequest request,
       final ResponseObserver<ReadRowsResponse> responseObserver,
       ApiCallContext context) {
+    ApiCallContext actualContext = this.context.merge(context);
     ReadRowsAttemptCallable attemptCallable =
         new ReadRowsAttemptCallable(
             innerCallable,
             resumptionStrategyPrototype.createNew(),
             request,
-            this.context,
+            actualContext,
             responseObserver);
 
-    RetryingFuture<Void> retryingFuture = executor.createFuture(attemptCallable, this.context);
+    RetryingFuture<Void> retryingFuture = executor.createFuture(attemptCallable, actualContext);
     attemptCallable.setExternalFuture(retryingFuture);
     attemptCallable.start();
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/readrows/ReadRowsRetryingCallable.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/readrows/ReadRowsRetryingCallable.java
@@ -55,15 +55,16 @@ public final class ReadRowsRetryingCallable
       ReadRowsRequest request,
       final ResponseObserver<ReadRowsResponse> responseObserver,
       ApiCallContext context) {
+    ApiCallContext actualContext = this.context.merge(context);
     ReadRowsAttemptCallable attemptCallable =
         new ReadRowsAttemptCallable(
             innerCallable,
             resumptionStrategyPrototype.createNew(),
             request,
-            this.context,
+            actualContext,
             responseObserver);
 
-    RetryingFuture<Void> retryingFuture = executor.createFuture(attemptCallable, this.context);
+    RetryingFuture<Void> retryingFuture = executor.createFuture(attemptCallable, actualContext);
     attemptCallable.setExternalFuture(retryingFuture);
     attemptCallable.start();
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/readrows/ReadRowsRetryingCallable.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/readrows/ReadRowsRetryingCallable.java
@@ -55,15 +55,16 @@ public final class ReadRowsRetryingCallable
       ReadRowsRequest request,
       final ResponseObserver<ReadRowsResponse> responseObserver,
       ApiCallContext context) {
+    ApiCallContext actualContext = this.context.merge(context);
     ReadRowsAttemptCallable attemptCallable =
         new ReadRowsAttemptCallable(
             innerCallable,
             resumptionStrategyPrototype.createNew(),
             request,
-            this.context,
+            actualContext,
             responseObserver);
 
-    RetryingFuture<Void> retryingFuture = executor.createFuture(attemptCallable, this.context);
+    RetryingFuture<Void> retryingFuture = executor.createFuture(attemptCallable, actualContext);
     attemptCallable.setExternalFuture(retryingFuture);
     attemptCallable.start();
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
