### PR TITLE
fix: Persist missingValueInterpretationMap in StreamWriter's Builder

### DIFF
--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -200,17 +200,7 @@
   <difference>
     <differenceType>7002</differenceType>
     <className>com/google/cloud/bigquery/storage/v1/JsonStreamWriter</className>
-    <method>java.util.Map getMissingValueInterpretationMap()</method>
-  </difference>
-  <difference>
-    <differenceType>7002</differenceType>
-    <className>com/google/cloud/bigquery/storage/v1/JsonStreamWriter</className>
     <method>void setMissingValueInterpretationMap(java.util.Map)</method>
-  </difference>
-  <difference>
-    <differenceType>7002</differenceType>
-    <className>com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter</className>
-    <method>java.util.Map getMissingValueInterpretationMap()</method>
   </difference>
   <difference>
     <differenceType>7002</differenceType>

--- a/google-cloud-bigquerystorage/clirr-ignored-differences.xml
+++ b/google-cloud-bigquerystorage/clirr-ignored-differences.xml
@@ -197,5 +197,30 @@
     <differenceType>1001</differenceType>
     <className>com/google/cloud/bigquery/storage/v1/StreamWriter$SingleConnectionOrConnectionPool</className>
   </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/bigquery/storage/v1/JsonStreamWriter</className>
+    <method>java.util.Map getMissingValueInterpretationMap()</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/bigquery/storage/v1/JsonStreamWriter</className>
+    <method>void setMissingValueInterpretationMap(java.util.Map)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter</className>
+    <method>java.util.Map getMissingValueInterpretationMap()</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter</className>
+    <method>void setMissingValueInterpretationMap(java.util.Map)</method>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/bigquery/storage/v1/StreamWriter</className>
+    <method>void setMissingValueInterpretationMap(java.util.Map)</method>
+  </difference>
 </differences>
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -120,24 +120,6 @@ public class JsonStreamWriter implements AutoCloseable {
   }
 
   /**
-   * Sets the missing value interpretation map for the JsonStreamWriter. The input
-   * missingValueInterpretationMap is used for all append requests unless otherwise changed.
-   *
-   * @param missingValueInterpretationMap the missing value interpretation map used by the
-   *     JsonStreamWriter.
-   */
-  public void setMissingValueInterpretationMap(
-      Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap) {
-    this.schemaAwareStreamWriter.setMissingValueInterpretationMap(missingValueInterpretationMap);
-  }
-
-  /** @return the missing value interpretation map used for the writer. */
-  public Map<String, AppendRowsRequest.MissingValueInterpretation>
-      getMissingValueInterpretationMap() {
-    return this.schemaAwareStreamWriter.getMissingValueInterpretationMap();
-  }
-
-  /**
    * newBuilder that constructs a JsonStreamWriter builder with BigQuery client being initialized by
    * StreamWriter by default.
    *
@@ -411,6 +393,21 @@ public class JsonStreamWriter implements AutoCloseable {
         AppendRowsRequest.MissingValueInterpretation defaultMissingValueInterpretation) {
       this.schemaAwareStreamWriterBuilder.setDefaultMissingValueInterpretation(
           defaultMissingValueInterpretation);
+      return this;
+    }
+
+    /**
+     * Sets the missing value interpretation map for the JsonStreamWriter. The input
+     * missingValueInterpretationMap is used for all append requests unless otherwise changed.
+     *
+     * @param missingValueInterpretationMap the missing value interpretation map used by the
+     *     JsonStreamWriter.
+     * @return Builder
+     */
+    public Builder setMissingValueInterpretationMap(
+        Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap) {
+      this.schemaAwareStreamWriterBuilder.setMissingValueInterpretationMap(
+          missingValueInterpretationMap);
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -119,6 +119,12 @@ public class JsonStreamWriter implements AutoCloseable {
     return this.schemaAwareStreamWriter.getInflightWaitSeconds();
   }
 
+  /** @return the missing value interpretation map used for the writer. */
+  public Map<String, AppendRowsRequest.MissingValueInterpretation>
+      getMissingValueInterpretationMap() {
+    return this.schemaAwareStreamWriter.getMissingValueInterpretationMap();
+  }
+
   /**
    * newBuilder that constructs a JsonStreamWriter builder with BigQuery client being initialized by
    * StreamWriter by default.

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -299,6 +299,12 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
     return streamWriter.getInflightWaitSeconds();
   }
 
+  /** @return the missing value interpretation map used for the writer. */
+  public Map<String, AppendRowsRequest.MissingValueInterpretation>
+      getMissingValueInterpretationMap() {
+    return streamWriter.getMissingValueInterpretationMap();
+  }
+
   /** Sets all StreamWriter settings. */
   private void setStreamWriterSettings(
       @Nullable TransportChannelProvider channelProvider,

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java
@@ -105,6 +105,7 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
     streamWriterBuilder.setLocation(builder.location);
     streamWriterBuilder.setDefaultMissingValueInterpretation(
         builder.defaultMissingValueInterpretation);
+    streamWriterBuilder.setMissingValueInterpretationMap(builder.missingValueInterpretationMap);
     streamWriterBuilder.setClientId(builder.clientId);
     streamWriterBuilder.setEnableLatencyProfiler(builder.enableRequestProfiler);
     requestProfilerHook = new RequestProfiler.RequestProfilerHook(builder.enableRequestProfiler);
@@ -298,24 +299,6 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
     return streamWriter.getInflightWaitSeconds();
   }
 
-  /**
-   * Sets the missing value interpretation map for the SchemaAwareStreamWriter. The input
-   * missingValueInterpretationMap is used for all append requests unless otherwise changed.
-   *
-   * @param missingValueInterpretationMap the missing value interpretation map used by the
-   *     SchemaAwareStreamWriter.
-   */
-  public void setMissingValueInterpretationMap(
-      Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap) {
-    streamWriter.setMissingValueInterpretationMap(missingValueInterpretationMap);
-  }
-
-  /** @return the missing value interpretation map used for the writer. */
-  public Map<String, AppendRowsRequest.MissingValueInterpretation>
-      getMissingValueInterpretationMap() {
-    return streamWriter.getMissingValueInterpretationMap();
-  }
-
   /** Sets all StreamWriter settings. */
   private void setStreamWriterSettings(
       @Nullable TransportChannelProvider channelProvider,
@@ -475,6 +458,8 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
 
     private AppendRowsRequest.MissingValueInterpretation defaultMissingValueInterpretation =
         MissingValueInterpretation.MISSING_VALUE_INTERPRETATION_UNSPECIFIED;
+    private Map<String, AppendRowsRequest.MissingValueInterpretation>
+        missingValueInterpretationMap = new HashMap();
     private String clientId;
 
     private boolean enableRequestProfiler = false;
@@ -681,6 +666,20 @@ public class SchemaAwareStreamWriter<T> implements AutoCloseable {
     public Builder setDefaultMissingValueInterpretation(
         AppendRowsRequest.MissingValueInterpretation defaultMissingValueInterpretation) {
       this.defaultMissingValueInterpretation = defaultMissingValueInterpretation;
+      return this;
+    }
+
+    /**
+     * Sets the missing value interpretation map for the SchemaAwareStreamWriter. The input
+     * missingValueInterpretationMap is used for all append requests unless otherwise changed.
+     *
+     * @param missingValueInterpretationMap the missing value interpretation map used by the
+     *     SchemaAwareStreamWriter.
+     * @return Builder
+     */
+    public Builder setMissingValueInterpretationMap(
+        Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap) {
+      this.missingValueInterpretationMap = missingValueInterpretationMap;
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -68,11 +68,6 @@ public class StreamWriter implements AutoCloseable {
   // Cache of location info for a given dataset.
   private static Map<String, String> projectAndDatasetToLocation = new ConcurrentHashMap<>();
 
-  // Map of fields to their MissingValueInterpretation, which dictates how a field should be
-  // populated when it is missing from an input user row.
-  private Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap =
-      new HashMap();
-
   /*
    * The identifier of stream to write to.
    */
@@ -102,6 +97,11 @@ public class StreamWriter implements AutoCloseable {
    */
   private AppendRowsRequest.MissingValueInterpretation defaultMissingValueInterpretation =
       MissingValueInterpretation.MISSING_VALUE_INTERPRETATION_UNSPECIFIED;
+
+  // Map of fields to their MissingValueInterpretation, which dictates how a field should be
+  // populated when it is missing from an input user row.
+  private Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap =
+      new HashMap();
 
   /**
    * Stream can access a single connection or a pool of connection depending on whether multiplexing
@@ -229,6 +229,7 @@ public class StreamWriter implements AutoCloseable {
     this.streamName = builder.streamName;
     this.writerSchema = builder.writerSchema;
     this.defaultMissingValueInterpretation = builder.defaultMissingValueInterpretation;
+    this.missingValueInterpretationMap = builder.missingValueInterpretationMap;
     BigQueryWriteSettings clientSettings = getBigQueryWriteSettings(builder);
     this.requestProfilerHook =
         new RequestProfiler.RequestProfilerHook(builder.enableRequestProfiler);
@@ -418,18 +419,6 @@ public class StreamWriter implements AutoCloseable {
                   + "value is %s.",
               storedLimitExceededBehavior, builder.limitExceededBehavior));
     }
-  }
-
-  /**
-   * Sets the missing value interpretation map for the stream writer. The input
-   * missingValueInterpretationMap is used for all write requests unless otherwise changed.
-   *
-   * @param missingValueInterpretationMap the missing value interpretation map used by stream
-   *     writer.
-   */
-  public void setMissingValueInterpretationMap(
-      Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap) {
-    this.missingValueInterpretationMap = missingValueInterpretationMap;
   }
 
   /**
@@ -700,6 +689,9 @@ public class StreamWriter implements AutoCloseable {
     private AppendRowsRequest.MissingValueInterpretation defaultMissingValueInterpretation =
         MissingValueInterpretation.MISSING_VALUE_INTERPRETATION_UNSPECIFIED;
 
+    private Map<String, AppendRowsRequest.MissingValueInterpretation>
+        missingValueInterpretationMap = new HashMap();
+
     private boolean enableRequestProfiler = false;
     private boolean enableOpenTelemetry = false;
 
@@ -848,6 +840,20 @@ public class StreamWriter implements AutoCloseable {
     public Builder setDefaultMissingValueInterpretation(
         AppendRowsRequest.MissingValueInterpretation defaultMissingValueInterpretation) {
       this.defaultMissingValueInterpretation = defaultMissingValueInterpretation;
+      return this;
+    }
+
+    /**
+     * Sets the missing value interpretation map for the stream writer. The input
+     * missingValueInterpretationMap is used for all write requests unless otherwise changed.
+     *
+     * @param missingValueInterpretationMap the missing value interpretation map used by stream
+     *     writer.
+     * @return Builder
+     */
+    public Builder setMissingValueInterpretationMap(
+        Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueInterpretationMap) {
+      this.missingValueInterpretationMap = missingValueInterpretationMap;
       return this;
     }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -893,6 +893,8 @@ public class JsonStreamWriterTest {
               .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
               .build());
       testBigQueryWrite.addResponse(createAppendResponse(1));
+      // Verify the map before the writer is refreshed
+      assertEquals(missingValueMap, writer.getMissingValueInterpretationMap());
       testBigQueryWrite.addResponse(createAppendResponse(2));
       testBigQueryWrite.addResponse(createAppendResponse(3));
 
@@ -944,6 +946,8 @@ public class JsonStreamWriterTest {
           testBigQueryWrite.getAppendRequests().get(2).getProtoRows().hasWriterSchema()
               || testBigQueryWrite.getAppendRequests().get(3).getProtoRows().hasWriterSchema());
 
+      // Verify the map after the writer is refreshed
+      assertEquals(missingValueMap, writer.getMissingValueInterpretationMap());
       assertEquals(
           testBigQueryWrite.getAppendRequests().get(3).getDefaultMissingValueInterpretation(),
           MissingValueInterpretation.DEFAULT_VALUE);
@@ -1617,6 +1621,8 @@ public class JsonStreamWriterTest {
             .setMissingValueInterpretationMap(missingValueMap)
             .setTraceId("test:empty")
             .build()) {
+
+      assertEquals(missingValueMap, writer.getMissingValueInterpretationMap());
 
       testBigQueryWrite.addResponse(
           AppendRowsResponse.newBuilder()

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriterTest.java
@@ -869,6 +869,91 @@ public class JsonStreamWriterTest {
   }
 
   @Test
+  public void testSimpleSchemaUpdate_withInterpretationMap() throws Exception {
+    testBigQueryWrite.addResponse(
+        WriteStream.newBuilder()
+            .setName(TEST_STREAM)
+            .setTableSchema(TABLE_SCHEMA)
+            .setLocation("us")
+            .build());
+    Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueMap = new HashMap<>();
+    missingValueMap.put("col1", AppendRowsRequest.MissingValueInterpretation.NULL_VALUE);
+    missingValueMap.put("col3", AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE);
+
+    try (JsonStreamWriter writer =
+        getTestJsonStreamWriterBuilder(TEST_STREAM)
+            .setDefaultMissingValueInterpretation(MissingValueInterpretation.DEFAULT_VALUE)
+            .setMissingValueInterpretationMap(missingValueMap)
+            .build()) {
+
+      testBigQueryWrite.addResponse(
+          AppendRowsResponse.newBuilder()
+              .setAppendResult(
+                  AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(0)).build())
+              .setUpdatedSchema(UPDATED_TABLE_SCHEMA)
+              .build());
+      testBigQueryWrite.addResponse(createAppendResponse(1));
+      testBigQueryWrite.addResponse(createAppendResponse(2));
+      testBigQueryWrite.addResponse(createAppendResponse(3));
+
+      // First batch of appends. First append request will return an updated-schema, but the second
+      // and maybe the third append will be processed before the first response will refresh the
+      // StreamWriter.
+      JSONObject foo = new JSONObject();
+      foo.put("foo", "aaa");
+      JSONArray jsonArr = new JSONArray();
+      jsonArr.put(foo);
+
+      ApiFuture<AppendRowsResponse> appendFuture1 = writer.append(jsonArr);
+      ApiFuture<AppendRowsResponse> appendFuture2 = writer.append(jsonArr);
+      ApiFuture<AppendRowsResponse> appendFuture3 = writer.append(jsonArr);
+
+      assertEquals(0L, appendFuture1.get().getAppendResult().getOffset().getValue());
+      assertEquals(1L, appendFuture2.get().getAppendResult().getOffset().getValue());
+      assertEquals(2L, appendFuture3.get().getAppendResult().getOffset().getValue());
+
+      // Another append, this time with columns to match the updated schema.
+      JSONObject updatedFoo = new JSONObject();
+      updatedFoo.put("foo", "aaa");
+      updatedFoo.put("bar", "bbb");
+      JSONArray updatedJsonArr = new JSONArray();
+      updatedJsonArr.put(updatedFoo);
+      ApiFuture<AppendRowsResponse> appendFuture4 = writer.append(updatedJsonArr);
+
+      assertEquals(3L, appendFuture4.get().getAppendResult().getOffset().getValue());
+      assertEquals(4, testBigQueryWrite.getAppendRequests().size());
+      assertEquals(
+          1,
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(3)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRowsCount());
+      assertEquals(
+          testBigQueryWrite
+              .getAppendRequests()
+              .get(3)
+              .getProtoRows()
+              .getRows()
+              .getSerializedRows(0),
+          UpdatedFooType.newBuilder().setFoo("aaa").setBar("bbb").build().toByteString());
+
+      assertTrue(testBigQueryWrite.getAppendRequests().get(0).getProtoRows().hasWriterSchema());
+      assertTrue(
+          testBigQueryWrite.getAppendRequests().get(2).getProtoRows().hasWriterSchema()
+              || testBigQueryWrite.getAppendRequests().get(3).getProtoRows().hasWriterSchema());
+
+      assertEquals(
+          testBigQueryWrite.getAppendRequests().get(3).getDefaultMissingValueInterpretation(),
+          MissingValueInterpretation.DEFAULT_VALUE);
+      assertEquals(
+          testBigQueryWrite.getAppendRequests().get(3).getMissingValueInterpretations(),
+          missingValueMap);
+    }
+  }
+
+  @Test
   public void testWithoutIgnoreUnknownFieldsUpdateImmeidateSuccess() throws Exception {
     TableSchema tableSchema = TableSchema.newBuilder().addFields(0, TEST_INT).build();
     TableSchema updatedSchema =
@@ -1523,14 +1608,15 @@ public class JsonStreamWriterTest {
     JSONArray jsonArr = new JSONArray();
     jsonArr.put(flexible);
 
-    try (JsonStreamWriter writer =
-        getTestJsonStreamWriterBuilder(TEST_STREAM, tableSchema).setTraceId("test:empty").build()) {
+    Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueMap = new HashMap<>();
+    missingValueMap.put("col1", AppendRowsRequest.MissingValueInterpretation.NULL_VALUE);
+    missingValueMap.put("col3", AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE);
 
-      Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueMap = new HashMap<>();
-      missingValueMap.put("col1", AppendRowsRequest.MissingValueInterpretation.NULL_VALUE);
-      missingValueMap.put("col3", AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE);
-      writer.setMissingValueInterpretationMap(missingValueMap);
-      assertEquals(missingValueMap, writer.getMissingValueInterpretationMap());
+    try (JsonStreamWriter writer =
+        getTestJsonStreamWriterBuilder(TEST_STREAM, tableSchema)
+            .setMissingValueInterpretationMap(missingValueMap)
+            .setTraceId("test:empty")
+            .build()) {
 
       testBigQueryWrite.addResponse(
           AppendRowsResponse.newBuilder()

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -171,12 +171,15 @@ public class StreamWriterTest {
         .build();
   }
 
-  private StreamWriter getTestStreamWriter() throws IOException {
+  private StreamWriter.Builder getTestStreamWriterBuilder() throws IOException {
     return StreamWriter.newBuilder(TEST_STREAM_1, client)
         .setWriterSchema(createProtoSchema())
         .setTraceId(TEST_TRACE_ID)
-        .setMaxRetryDuration(java.time.Duration.ofSeconds(5))
-        .build();
+        .setMaxRetryDuration(java.time.Duration.ofSeconds(5));
+  }
+
+  private StreamWriter getTestStreamWriter() throws IOException {
+    return getTestStreamWriterBuilder().build();
   }
 
   private StreamWriter getTestStreamWriterRetryEnabled() throws IOException {
@@ -1583,47 +1586,53 @@ public class StreamWriterTest {
 
   @Test
   public void testSetAndGetMissingValueInterpretationMap() throws Exception {
-    StreamWriter writer = getTestStreamWriter();
+    StreamWriter.Builder writerBuilder = getTestStreamWriterBuilder();
     Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueMap = new HashMap();
     missingValueMap.put("col1", AppendRowsRequest.MissingValueInterpretation.NULL_VALUE);
     missingValueMap.put("col3", AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE);
-    writer.setMissingValueInterpretationMap(missingValueMap);
+    writerBuilder.setMissingValueInterpretationMap(missingValueMap);
+    StreamWriter writer = writerBuilder.build();
     assertEquals(missingValueMap, writer.getMissingValueInterpretationMap());
   }
 
   @Test
+  public void testAppendWithoutMissingValueMap() throws Exception {
+    try (StreamWriter writer = getTestStreamWriter()) {
+
+      testBigQueryWrite.addResponse(createAppendResponse(0));
+
+      ApiFuture<AppendRowsResponse> responseFuture =
+          writer.append(createProtoRows(new String[] {String.valueOf(0)}), 0);
+
+      assertEquals(0, responseFuture.get().getAppendResult().getOffset().getValue());
+
+      verifyAppendRequests(1);
+      assertTrue(testBigQueryWrite.getAppendRequests().get(0).getMissingValueInterpretations().isEmpty());
+    }
+  }
+
+  @Test
   public void testAppendWithMissingValueMap() throws Exception {
-    StreamWriter writer = getTestStreamWriter();
-
-    long appendCount = 2;
-    testBigQueryWrite.addResponse(createAppendResponse(0));
-    testBigQueryWrite.addResponse(createAppendResponse(1));
-
-    List<ApiFuture<AppendRowsResponse>> futures = new ArrayList<>();
-    // The first append doesn't use a missing value map.
-    futures.add(writer.append(createProtoRows(new String[] {String.valueOf(0)}), 0));
-
-    // The second append uses a missing value map.
     Map<String, AppendRowsRequest.MissingValueInterpretation> missingValueMap = new HashMap();
     missingValueMap.put("col1", AppendRowsRequest.MissingValueInterpretation.NULL_VALUE);
     missingValueMap.put("col3", AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE);
-    writer.setMissingValueInterpretationMap(missingValueMap);
-    futures.add(writer.append(createProtoRows(new String[] {String.valueOf(1)}), 1));
 
-    for (int i = 0; i < appendCount; i++) {
-      assertEquals(i, futures.get(i).get().getAppendResult().getOffset().getValue());
+    try (StreamWriter writer =
+        getTestStreamWriterBuilder().setMissingValueInterpretationMap(missingValueMap).build()) {
+
+      testBigQueryWrite.addResponse(createAppendResponse(0));
+
+      ApiFuture<AppendRowsResponse> responseFuture =
+          writer.append(createProtoRows(new String[] {String.valueOf(0)}), 0);
+
+      assertEquals(0, responseFuture.get().getAppendResult().getOffset().getValue());
+
+      verifyAppendRequests(1);
+
+      assertEquals(
+          testBigQueryWrite.getAppendRequests().get(0).getMissingValueInterpretations(),
+          missingValueMap);
     }
-
-    // Ensure that the AppendRowsRequest for the first append operation does not have a missing
-    // value map, and that the second AppendRowsRequest has the missing value map provided in the
-    // second append.
-    verifyAppendRequests(appendCount);
-    AppendRowsRequest request1 = testBigQueryWrite.getAppendRequests().get(0);
-    AppendRowsRequest request2 = testBigQueryWrite.getAppendRequests().get(1);
-    assertTrue(request1.getMissingValueInterpretations().isEmpty());
-    assertEquals(request2.getMissingValueInterpretations(), missingValueMap);
-
-    writer.close();
   }
 
   @Test(timeout = 10000)

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
@@ -1607,7 +1607,8 @@ public class StreamWriterTest {
       assertEquals(0, responseFuture.get().getAppendResult().getOffset().getValue());
 
       verifyAppendRequests(1);
-      assertTrue(testBigQueryWrite.getAppendRequests().get(0).getMissingValueInterpretations().isEmpty());
+      assertTrue(
+          testBigQueryWrite.getAppendRequests().get(0).getMissingValueInterpretations().isEmpty());
     }
   }
 


### PR DESCRIPTION
In case the StreamWriter is recreated, like during schema update, the map will be used in the new StreamWriter too.