### PR TITLE
chore: setup 3.5.x lts branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -26,3 +26,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 2.47.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 3.5.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -100,6 +100,20 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - javadoc
+  - pattern: 3.5.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (17)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - cla/google
+      - javadoc
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
enable releases