### PR TITLE
chore: remove auth dependencies version and rely on sdk-platform-java-config

### DIFF
--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -156,11 +156,6 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
   </dependency>
-  <dependency>
-    <groupId>com.google.auth</groupId>
-    <artifactId>google-auth-library-credentials</artifactId>
-    <version>1.27.0</version>
-  </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
@@ -223,12 +218,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.27.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -156,6 +156,10 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
   </dependency>
+  <dependency>
+    <groupId>com.google.auth</groupId>
+    <artifactId>google-auth-library-credentials</artifactId>
+  </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
@@ -218,6 +222,11 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
These dependencies were added in https://github.com/googleapis/java-bigquerystorage/pull/2388 with hardcoded versions. 
We prefer getting these versions from `sdk-platform-java-config` (includes both auth and gax versions).

auth is included in dependencyManagement [here](https://github.com/googleapis/sdk-platform-java/blob/aa81ece23e78f6aeec124cbcc76a2e130409ecbf/gapic-generator-java-bom/pom.xml#L28) in `gapic-generator-java-bom`, which is part of `first-party-dependencies`, and eventually included via `sdk-platform-java-config`.