### PR TITLE
test: fix samples failure due to dep. conflict

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -39,6 +39,17 @@
       <artifactId>google-cloud-bigquery</artifactId>
       <version>2.43.0</version>
     </dependency>
+
+    <!--
+      Explicitly set google-cloud-monitoring due to conflict with
+      com.google.cloud.opentelemetry.exporter-metrics.
+    -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-monitoring</artifactId>
+      <version>3.52.0</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -38,6 +38,17 @@
       <artifactId>google-cloud-bigquery</artifactId>
       <version>2.43.0</version>
     </dependency>
+
+    <!--
+      Explicitly set google-cloud-monitoring due to conflict with
+      com.google.cloud.opentelemetry.exporter-metrics.
+    -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-monitoring</artifactId>
+      <version>3.52.0</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>


### PR DESCRIPTION
com.google.cloud.opentelemetry.exporter-metrics depends on a very old version of com.google.cloud.google-cloud-monitoring which conflicts with newer com.google.cloud.google-cloud-bigquery builds

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2667 #2668 #2669 #2670 #2671 #2672 #2673 #2674 ☕️
