### PR TITLE
fix: update BigQuerySchemaUtil to use non-deprecated hasExtension

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQuerySchemaUtil.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQuerySchemaUtil.java
@@ -15,7 +15,9 @@
  */
 package com.google.cloud.bigquery.storage.v1;
 
+import com.google.protobuf.DescriptorProtos.FieldOptions;
 import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.ExtensionLite;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
@@ -74,8 +76,12 @@ public class BigQuerySchemaUtil {
    * @return columnName annotation if present, otherwise return the field name.
    */
   public static String getFieldName(FieldDescriptor fieldDescriptor) {
-    return fieldDescriptor.getOptions().hasExtension(AnnotationsProto.columnName)
-        ? fieldDescriptor.getOptions().getExtension(AnnotationsProto.columnName)
+    return fieldDescriptor
+            .getOptions()
+            .hasExtension((ExtensionLite<FieldOptions, String>) AnnotationsProto.columnName)
+        ? fieldDescriptor
+            .getOptions()
+            .getExtension((ExtensionLite<FieldOptions, String>) AnnotationsProto.columnName)
         : fieldDescriptor.getName();
   }
 }


### PR DESCRIPTION
This is to unblock protocol buffer version updates.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2733 ☕️