### PR TITLE
pschnayder: Updating the StreamWriterClosedException to include client side mitigation suggestions from the public documentation

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -585,11 +585,21 @@ class ConnectionWorker implements AutoCloseable {
       }
 
       if (connectionFinalStatus != null) {
+        String connectionFinalStatusString;
+        if (connectionFinalStatus
+            .toString()
+            .contains("com.google.api.gax.rpc.UnavailableException")) {
+          connectionFinalStatusString =
+              connectionFinalStatus.toString()
+                  + " This is a most likely a transient condition and may be corrected by retrying"
+                  + " with a backoff.";
+        } else {
+          connectionFinalStatusString = connectionFinalStatus.toString();
+        }
         requestWrapper.appendResult.setException(
             new Exceptions.StreamWriterClosedException(
                 Status.fromCode(Status.Code.FAILED_PRECONDITION)
-                    .withDescription(
-                        "Connection is closed due to " + connectionFinalStatus.toString()),
+                    .withDescription("Connection is closed due to " + connectionFinalStatusString),
                 streamName,
                 writerId));
         return requestWrapper.appendResult;

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ConnectionWorker.java
@@ -591,7 +591,7 @@ class ConnectionWorker implements AutoCloseable {
             .contains("com.google.api.gax.rpc.UnavailableException")) {
           connectionFinalStatusString =
               connectionFinalStatus.toString()
-                  + " This is a most likely a transient condition and may be corrected by retrying"
+                  + ". This is a most likely a transient condition and may be corrected by retrying"
                   + " with a backoff.";
         } else {
           connectionFinalStatusString = connectionFinalStatus.toString();


### PR DESCRIPTION
Improved error message allows end users to have actionable remediation for encountered com.google.api.gax.rpc.UnavailableException based on https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.rpc.UnavailableException

The feature request is created here -> https://github.com/googleapis/java-bigquerystorage/issues/2783