### PR TITLE
deps: update dependency com.google.cloud:google-cloud-bigquery to v2.45.0

### DIFF
--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
@@ -1755,24 +1755,16 @@ public class ITBigQueryWriteManualClientTest {
             QueryJobConfiguration.newBuilder("SELECT * from " + DATASET + '.' + TABLE2).build());
     Iterator<FieldValueList> queryIter = queryResult.getValues().iterator();
     assertTrue(queryIter.hasNext());
-    // SHOULD FAIL.
-    // System.out.println("CHUONGPH: " + queryIter.next().get(1).getRepeatedValue().toString());
     assertEquals(
-        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa, useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa, useInt64Timestamps=false}], useInt64Timestamps=false}]",
+        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa,"
+            + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa,"
+            + " useInt64Timestamps=false}], useInt64Timestamps=false}]",
         queryIter.next().get(1).getRepeatedValue().toString());
     assertEquals(
-        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb, useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=bbb, useInt64Timestamps=false}], useInt64Timestamps=false}]",
+        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb,"
+            + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=bbb,"
+            + " useInt64Timestamps=false}], useInt64Timestamps=false}]",
         queryIter.next().get(1).getRepeatedValue().toString());
-    // assertEquals(
-    //     "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa,"
-    //         + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa,"
-    //         + " useInt64Timestamps=false}]}]",
-    //     queryIter.next().get(1).getRepeatedValue().toString());
-    // assertEquals(
-    //     "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb,"
-    //         + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=bbb,"
-    //         + " useInt64Timestamps=false}]}]",
-    //     queryIter.next().get(1).getRepeatedValue().toString());
     assertFalse(queryIter.hasNext());
   }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
@@ -1756,17 +1756,23 @@ public class ITBigQueryWriteManualClientTest {
     Iterator<FieldValueList> queryIter = queryResult.getValues().iterator();
     assertTrue(queryIter.hasNext());
     // SHOULD FAIL.
-    System.out.println("CHUONGPH: " + queryIter.next().get(1).getRepeatedValue().toString());
+    // System.out.println("CHUONGPH: " + queryIter.next().get(1).getRepeatedValue().toString());
     assertEquals(
-        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa,"
-            + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa,"
-            + " useInt64Timestamps=false}]}]",
+        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa, useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa, useInt64Timestamps=false}], useInt64Timestamps=false}]",
         queryIter.next().get(1).getRepeatedValue().toString());
     assertEquals(
-        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb,"
-            + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=bbb,"
-            + " useInt64Timestamps=false}]}]",
+        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb, useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=bbb, useInt64Timestamps=false}], useInt64Timestamps=false}]",
         queryIter.next().get(1).getRepeatedValue().toString());
+    // assertEquals(
+    //     "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa,"
+    //         + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa,"
+    //         + " useInt64Timestamps=false}]}]",
+    //     queryIter.next().get(1).getRepeatedValue().toString());
+    // assertEquals(
+    //     "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb,"
+    //         + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=bbb,"
+    //         + " useInt64Timestamps=false}]}]",
+    //     queryIter.next().get(1).getRepeatedValue().toString());
     assertFalse(queryIter.hasNext());
   }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
@@ -1756,12 +1756,14 @@ public class ITBigQueryWriteManualClientTest {
     Iterator<FieldValueList> queryIter = queryResult.getValues().iterator();
     assertTrue(queryIter.hasNext());
     assertEquals(
-        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa},"
-            + " FieldValue{attribute=PRIMITIVE, value=aaa}]}]",
+        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa,"
+            + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa,"
+            + " useInt64Timestamps=false}]}]",
         queryIter.next().get(1).getRepeatedValue().toString());
     assertEquals(
-        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb},"
-            + " FieldValue{attribute=PRIMITIVE, value=bbb}]}]",
+        "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=bbb,"
+            + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=bbb,"
+            + " useInt64Timestamps=false}]}]",
         queryIter.next().get(1).getRepeatedValue().toString());
     assertFalse(queryIter.hasNext());
   }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteManualClientTest.java
@@ -1755,6 +1755,8 @@ public class ITBigQueryWriteManualClientTest {
             QueryJobConfiguration.newBuilder("SELECT * from " + DATASET + '.' + TABLE2).build());
     Iterator<FieldValueList> queryIter = queryResult.getValues().iterator();
     assertTrue(queryIter.hasNext());
+    // SHOULD FAIL.
+    System.out.println("CHUONGPH: " + queryIter.next().get(1).getRepeatedValue().toString());
     assertEquals(
         "[FieldValue{attribute=REPEATED, value=[FieldValue{attribute=PRIMITIVE, value=aaa,"
             + " useInt64Timestamps=false}, FieldValue{attribute=PRIMITIVE, value=aaa,"

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery</artifactId>
-        <version>2.44.0</version>
+        <version>2.45.0</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>2.44.0</version>
+      <version>2.45.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>2.44.0</version>
+      <version>2.45.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>2.44.0</version>
+      <version>2.45.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

This PR edits generated files to update the dependency. This is normally done by renovate-bot such as #2808. However, due to a recent change to the FieldValue.toString() method, the integration test validation also needs to be simultaneously updated when the dep is upgraded. Unfortunately, I do not have permissions to edit the renovate-bot branch. After this merges, #2808 will be closed and normal renovate-bot dep. update will continue in later PRs.

Fixes # b/384727725 ☕️
