### PR TITLE
fix: clarify connection pool document

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/JsonStreamWriter.java
@@ -312,8 +312,21 @@ public class JsonStreamWriter implements AutoCloseable {
     }
 
     /**
-     * Enable multiplexing for this writer. In multiplexing mode tables will share the same
-     * connection if possible until the connection is overwhelmed.
+     * Enables a static shared bidi-streaming connection pool that would dynamically scale up
+     * connections based on backlog within each individual connection. A single table's traffic
+     * might be splitted into multiple connections if needed. Different tables' traffic can also be
+     * multiplexed within the same connection.
+     *
+     * <pre>
+     * Each connection pool would have a upper limit (default to 20) and lower limit (default to
+     * 2) for the number of active connections. This parameter can be tuned via a static method
+     * exposed on {@link ConnectionWorkerPool}.
+     *
+     * Example:
+     * ConnectionWorkerPool.setOptions(
+     *     Settings.builder().setMinConnectionsPerRegion(4).setMaxConnectionsPerRegion(10).build());
+     *
+     * </pre>
      *
      * @param enableConnectionPool
      * @return Builder

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -729,8 +729,21 @@ public class StreamWriter implements AutoCloseable {
     }
 
     /**
-     * Enable multiplexing for this writer. In multiplexing mode tables will share the same
-     * connection if possible until the connection is overwhelmed.
+     * Enables a static shared bidi-streaming connection pool that would dynamically scale up
+     * connections based on backlog within each individual connection. A single table's traffic
+     * might be splitted into multiple connections if needed. Different tables' traffic can also be
+     * multiplexed within the same connection.
+     *
+     * <pre>
+     * Each connection pool would have a upper limit (default to 20) and lower limit (default to
+     * 2) for the number of active connections. This parameter can be tuned via a static method
+     * exposed on {@link ConnectionWorkerPool}.
+     *
+     * Example:
+     * ConnectionWorkerPool.setOptions(
+     *     Settings.builder().setMinConnectionsPerRegion(4).setMaxConnectionsPerRegion(10).build());
+     *
+     * </pre>
      *
      * @param enableConnectionPool
      * @return Builder


### PR DESCRIPTION
The document was not indicating a connection pool would be scaled up even in single table situation

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquerystorage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
