### PR TITLE
feat(bigquery): Integrate Otel Tracing in storage lib

### DIFF
--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -167,11 +167,25 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-context</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-trace</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -170,6 +170,11 @@
 
     <!-- Test dependencies -->
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
@@ -20,9 +20,9 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStub;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -234,16 +234,23 @@ public class BigQueryReadClient implements BackgroundResource {
   public final ReadSession createReadSession(CreateReadSessionRequest request) {
     Span createReadSession = null;
     if (settings.isOpenTelemetryEnabled()) {
-      createReadSession = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.createReadSession")
-          .setAttribute("bq.storage.read_session.request.parent", request.getParent())
-          .setAttribute("bq.storage.read_session.request.max_stream_count", request.getMaxStreamCount())
-          .setAttribute("bq.storage.read_session.request.preferred_min_stream_count", request.getPreferredMinStreamCount())
-          .setAttribute("bq.storage.read_session.request.serialized_size", request.getSerializedSize())
-          .setAllAttributes(otelAttributesFrom(request.getReadSession()))
-          .startSpan();
+      createReadSession =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.createReadSession")
+              .setAttribute("bq.storage.read_session.request.parent", request.getParent())
+              .setAttribute(
+                  "bq.storage.read_session.request.max_stream_count", request.getMaxStreamCount())
+              .setAttribute(
+                  "bq.storage.read_session.request.preferred_min_stream_count",
+                  request.getPreferredMinStreamCount())
+              .setAttribute(
+                  "bq.storage.read_session.request.serialized_size", request.getSerializedSize())
+              .setAllAttributes(otelAttributesFrom(request.getReadSession()))
+              .startSpan();
     }
-    try (Scope createReadSessionScope = createReadSession != null ? createReadSession.makeCurrent() : null) {
+    try (Scope createReadSessionScope =
+        createReadSession != null ? createReadSession.makeCurrent() : null) {
       return createReadSessionCallable().call(request);
     } finally {
       if (createReadSession != null) {
@@ -284,11 +291,14 @@ public class BigQueryReadClient implements BackgroundResource {
   public final UnaryCallable<CreateReadSessionRequest, ReadSession> createReadSessionCallable() {
     Span createReadSessionCallable = null;
     if (settings.isOpenTelemetryEnabled()) {
-      createReadSessionCallable = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.createReadSessionCallable")
-          .startSpan();
+      createReadSessionCallable =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.createReadSessionCallable")
+              .startSpan();
     }
-    try (Scope createReadSessionCallableScope = createReadSessionCallable != null ? createReadSessionCallable.makeCurrent() : null) {
+    try (Scope createReadSessionCallableScope =
+        createReadSessionCallable != null ? createReadSessionCallable.makeCurrent() : null) {
       return stub.createReadSessionCallable();
     } finally {
       if (createReadSessionCallable != null) {
@@ -321,11 +331,14 @@ public class BigQueryReadClient implements BackgroundResource {
   public final ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable() {
     Span readRowsCallable = null;
     if (settings.isOpenTelemetryEnabled()) {
-      readRowsCallable = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.readRowsCallable")
-          .startSpan();
+      readRowsCallable =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.readRowsCallable")
+              .startSpan();
     }
-    try (Scope readRowsCallableScope = readRowsCallable != null ? readRowsCallable.makeCurrent() : null) {
+    try (Scope readRowsCallableScope =
+        readRowsCallable != null ? readRowsCallable.makeCurrent() : null) {
       return stub.readRowsCallable();
     } finally {
       if (readRowsCallable != null) {
@@ -361,12 +374,15 @@ public class BigQueryReadClient implements BackgroundResource {
   public final SplitReadStreamResponse splitReadStream(SplitReadStreamRequest request) {
     Span splitReadStream = null;
     if (settings.isOpenTelemetryEnabled()) {
-      splitReadStream = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.splitReadStream")
-          // TODO(liamhuffman): populate attributes
-          .startSpan();
+      splitReadStream =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.splitReadStream")
+              // TODO(liamhuffman): populate attributes
+              .startSpan();
     }
-    try (Scope splitReadStreamScope = splitReadStream != null ? splitReadStream.makeCurrent() : null) {
+    try (Scope splitReadStreamScope =
+        splitReadStream != null ? splitReadStream.makeCurrent() : null) {
       return splitReadStreamCallable().call(request);
     } finally {
       if (splitReadStream != null) {
@@ -402,11 +418,14 @@ public class BigQueryReadClient implements BackgroundResource {
       splitReadStreamCallable() {
     Span splitReadStreamCallable = null;
     if (settings.isOpenTelemetryEnabled()) {
-      splitReadStreamCallable = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.splitReadStreamCallable")
-          .startSpan();
+      splitReadStreamCallable =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.splitReadStreamCallable")
+              .startSpan();
     }
-    try (Scope readRowsCallableScope = splitReadStreamCallable != null ? splitReadStreamCallable.makeCurrent() : null) {
+    try (Scope readRowsCallableScope =
+        splitReadStreamCallable != null ? splitReadStreamCallable.makeCurrent() : null) {
       return stub.splitReadStreamCallable();
     } finally {
       if (splitReadStreamCallable != null) {
@@ -419,9 +438,11 @@ public class BigQueryReadClient implements BackgroundResource {
   public final void close() {
     Span close = null;
     if (settings.isOpenTelemetryEnabled()) {
-      close = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.close")
-          .startSpan();
+      close =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.close")
+              .startSpan();
     }
     try (Scope closeScope = close != null ? close.makeCurrent() : null) {
       stub.close();
@@ -436,9 +457,11 @@ public class BigQueryReadClient implements BackgroundResource {
   public void shutdown() {
     Span shutdown = null;
     if (settings.isOpenTelemetryEnabled()) {
-      shutdown = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.shutdown")
-          .startSpan();
+      shutdown =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.shutdown")
+              .startSpan();
     }
     try (Scope shutdownScope = shutdown != null ? shutdown.makeCurrent() : null) {
       stub.shutdown();
@@ -463,9 +486,11 @@ public class BigQueryReadClient implements BackgroundResource {
   public void shutdownNow() {
     Span shutdownNow = null;
     if (settings.isOpenTelemetryEnabled()) {
-      shutdownNow = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.shutdownNow")
-          .startSpan();
+      shutdownNow =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.shutdownNow")
+              .startSpan();
     }
     try (Scope shutdownNowScope = shutdownNow != null ? shutdownNow.makeCurrent() : null) {
       stub.shutdownNow();
@@ -480,13 +505,16 @@ public class BigQueryReadClient implements BackgroundResource {
   public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
     Span awaitTermination = null;
     if (settings.isOpenTelemetryEnabled()) {
-      awaitTermination = settings.getOpenTelemetryTracer()
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.awaitTermination")
-          .setAttribute("duration", duration)
-          .setAttribute("unit", unit.toString())
-          .startSpan();
+      awaitTermination =
+          settings
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.awaitTermination")
+              .setAttribute("duration", duration)
+              .setAttribute("unit", unit.toString())
+              .startSpan();
     }
-    try (Scope awaitTerminationScope = awaitTermination != null ? awaitTermination.makeCurrent() : null) {
+    try (Scope awaitTerminationScope =
+        awaitTermination != null ? awaitTermination.makeCurrent() : null) {
       return stub.awaitTermination(duration, unit);
     } finally {
       if (awaitTermination != null) {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
@@ -20,6 +20,9 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStub;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -229,7 +232,24 @@ public class BigQueryReadClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final ReadSession createReadSession(CreateReadSessionRequest request) {
-    return createReadSessionCallable().call(request);
+    Span createReadSession = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      createReadSession = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.createReadSession")
+          .setAttribute("bq.storage.read_session.request.parent", request.getParent())
+          .setAttribute("bq.storage.read_session.request.max_stream_count", request.getMaxStreamCount())
+          .setAttribute("bq.storage.read_session.request.preferred_min_stream_count", request.getPreferredMinStreamCount())
+          .setAttribute("bq.storage.read_session.request.serialized_size", request.getSerializedSize())
+          .setAllAttributes(otelAttributesFrom(request.getReadSession()))
+          .startSpan();
+    }
+    try (Scope createReadSessionScope = createReadSession != null ? createReadSession.makeCurrent() : null) {
+      return createReadSessionCallable().call(request);
+    } finally {
+      if (createReadSession != null) {
+        createReadSession.end();
+      }
+    }
   }
 
   /**
@@ -262,7 +282,19 @@ public class BigQueryReadClient implements BackgroundResource {
    * </code></pre>
    */
   public final UnaryCallable<CreateReadSessionRequest, ReadSession> createReadSessionCallable() {
-    return stub.createReadSessionCallable();
+    Span createReadSessionCallable = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      createReadSessionCallable = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.createReadSessionCallable")
+          .startSpan();
+    }
+    try (Scope createReadSessionCallableScope = createReadSessionCallable != null ? createReadSessionCallable.makeCurrent() : null) {
+      return stub.createReadSessionCallable();
+    } finally {
+      if (createReadSessionCallable != null) {
+        createReadSessionCallable.end();
+      }
+    }
   }
 
   /**
@@ -287,7 +319,19 @@ public class BigQueryReadClient implements BackgroundResource {
    * </code></pre>
    */
   public final ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable() {
-    return stub.readRowsCallable();
+    Span readRowsCallable = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      readRowsCallable = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.readRowsCallable")
+          .startSpan();
+    }
+    try (Scope readRowsCallableScope = readRowsCallable != null ? readRowsCallable.makeCurrent() : null) {
+      return stub.readRowsCallable();
+    } finally {
+      if (readRowsCallable != null) {
+        readRowsCallable.end();
+      }
+    }
   }
 
   /**
@@ -315,7 +359,20 @@ public class BigQueryReadClient implements BackgroundResource {
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final SplitReadStreamResponse splitReadStream(SplitReadStreamRequest request) {
-    return splitReadStreamCallable().call(request);
+    Span splitReadStream = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      splitReadStream = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.splitReadStream")
+          // TODO(liamhuffman): populate attributes
+          .startSpan();
+    }
+    try (Scope splitReadStreamScope = splitReadStream != null ? splitReadStream.makeCurrent() : null) {
+      return splitReadStreamCallable().call(request);
+    } finally {
+      if (splitReadStream != null) {
+        splitReadStream.end();
+      }
+    }
   }
 
   /**
@@ -343,17 +400,53 @@ public class BigQueryReadClient implements BackgroundResource {
    */
   public final UnaryCallable<SplitReadStreamRequest, SplitReadStreamResponse>
       splitReadStreamCallable() {
-    return stub.splitReadStreamCallable();
+    Span splitReadStreamCallable = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      splitReadStreamCallable = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.splitReadStreamCallable")
+          .startSpan();
+    }
+    try (Scope readRowsCallableScope = splitReadStreamCallable != null ? splitReadStreamCallable.makeCurrent() : null) {
+      return stub.splitReadStreamCallable();
+    } finally {
+      if (splitReadStreamCallable != null) {
+        splitReadStreamCallable.end();
+      }
+    }
   }
 
   @Override
   public final void close() {
-    stub.close();
+    Span close = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      close = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.close")
+          .startSpan();
+    }
+    try (Scope closeScope = close != null ? close.makeCurrent() : null) {
+      stub.close();
+    } finally {
+      if (close != null) {
+        close.end();
+      }
+    }
   }
 
   @Override
   public void shutdown() {
-    stub.shutdown();
+    Span shutdown = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      shutdown = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.shutdown")
+          .startSpan();
+    }
+    try (Scope shutdownScope = shutdown != null ? shutdown.makeCurrent() : null) {
+      stub.shutdown();
+    } finally {
+      if (shutdown != null) {
+        shutdown.end();
+      }
+    }
   }
 
   @Override
@@ -368,11 +461,56 @@ public class BigQueryReadClient implements BackgroundResource {
 
   @Override
   public void shutdownNow() {
-    stub.shutdownNow();
+    Span shutdownNow = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      shutdownNow = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.shutdownNow")
+          .startSpan();
+    }
+    try (Scope shutdownNowScope = shutdownNow != null ? shutdownNow.makeCurrent() : null) {
+      stub.shutdownNow();
+    } finally {
+      if (shutdownNow != null) {
+        shutdownNow.end();
+      }
+    }
   }
 
   @Override
   public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
-    return stub.awaitTermination(duration, unit);
+    Span awaitTermination = null;
+    if (settings.isOpenTelemetryEnabled()) {
+      awaitTermination = settings.getOpenTelemetryTracer()
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.awaitTermination")
+          .setAttribute("duration", duration)
+          .setAttribute("unit", unit.toString())
+          .startSpan();
+    }
+    try (Scope awaitTerminationScope = awaitTermination != null ? awaitTermination.makeCurrent() : null) {
+      return stub.awaitTermination(duration, unit);
+    } finally {
+      if (awaitTermination != null) {
+        awaitTermination.end();
+      }
+    }
+  }
+
+  public void disableOpenTelemetryTracing() {
+    settings.setEnableOpenTelemetryTracing(false);
+  }
+
+  public void enableOpenTelemetryTracing() {
+    settings.setEnableOpenTelemetryTracing(true);
+  }
+
+  private Attributes otelAttributesFrom(ReadSession readSession) {
+    return Attributes.builder()
+        .put("bq.storage.read_session.name", readSession.getName())
+        .put("bq.storage.read_session.data_format_value", readSession.getDataFormatValue())
+        .put("bq.storage.read_session.serialized_size", readSession.getSerializedSize())
+        .put("bq.storage.read_session.table", readSession.getTable())
+        .put("bq.storage.read_session.estimated_row_count", readSession.getEstimatedRowCount())
+        // TODO(liamhuffman): populate attributes
+        .build();
   }
 }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
@@ -238,14 +238,17 @@ public class BigQueryReadClient implements BackgroundResource {
           settings
               .getOpenTelemetryTracer()
               .spanBuilder("com.google.cloud.bigquery.storage.v1.read.createReadSession")
-              .setAttribute("bq.storage.read_session.request.parent", request.getParent())
               .setAttribute(
-                  "bq.storage.read_session.request.max_stream_count", request.getMaxStreamCount())
+                  "bq.storage.read_session.request.parent", getFieldAsString(request.getParent()))
+              .setAttribute(
+                  "bq.storage.read_session.request.max_stream_count",
+                  getFieldAsString(request.getMaxStreamCount()))
               .setAttribute(
                   "bq.storage.read_session.request.preferred_min_stream_count",
-                  request.getPreferredMinStreamCount())
+                  getFieldAsString(request.getPreferredMinStreamCount()))
               .setAttribute(
-                  "bq.storage.read_session.request.serialized_size", request.getSerializedSize())
+                  "bq.storage.read_session.request.serialized_size",
+                  getFieldAsString(request.getSerializedSize()))
               .setAllAttributes(otelAttributesFrom(request.getReadSession()))
               .startSpan();
     }
@@ -378,7 +381,7 @@ public class BigQueryReadClient implements BackgroundResource {
           settings
               .getOpenTelemetryTracer()
               .spanBuilder("com.google.cloud.bigquery.storage.v1.read.splitReadStream")
-              // TODO(liamhuffman): populate attributes
+              .setAllAttributes(otelAttributesFrom(request))
               .startSpan();
     }
     try (Scope splitReadStreamScope =
@@ -531,14 +534,46 @@ public class BigQueryReadClient implements BackgroundResource {
     settings.setEnableOpenTelemetryTracing(true);
   }
 
+  private static String getFieldAsString(Object field) {
+    return field == null ? "null" : field.toString();
+  }
+
   private Attributes otelAttributesFrom(ReadSession readSession) {
     return Attributes.builder()
-        .put("bq.storage.read_session.name", readSession.getName())
-        .put("bq.storage.read_session.data_format_value", readSession.getDataFormatValue())
-        .put("bq.storage.read_session.serialized_size", readSession.getSerializedSize())
-        .put("bq.storage.read_session.table", readSession.getTable())
-        .put("bq.storage.read_session.estimated_row_count", readSession.getEstimatedRowCount())
-        // TODO(liamhuffman): populate attributes
+        .put("bq.storage.read_session.name", getFieldAsString(readSession.getName()))
+        .put(
+            "bq.storage.read_session.data_format_value",
+            getFieldAsString(readSession.getDataFormatValue()))
+        .put(
+            "bq.storage.read_session.serialized_size",
+            getFieldAsString(readSession.getSerializedSize()))
+        .put("bq.storage.read_session.table", getFieldAsString(readSession.getTable()))
+        .put(
+            "bq.storage.read_session.estimated_row_count",
+            getFieldAsString(readSession.getEstimatedRowCount()))
+        .put(
+            "bq.storage.read_session.estimated_total_bytes_scanned",
+            getFieldAsString(readSession.getEstimatedTotalBytesScanned()))
+        .put(
+            "bq.storage.read_session.estimated_total_physical_bytes",
+            getFieldAsString(readSession.getEstimatedTotalPhysicalFileSize()))
+        .put(
+            "bq.storage.read_session.streams_count",
+            getFieldAsString(readSession.getStreamsCount()))
+        .put("bq.storage.read_session.trace_id", getFieldAsString(readSession.getTraceId()))
+        .put("bq.storage.read_session.expire_time", getFieldAsString(readSession.getExpireTime()))
+        .build();
+  }
+
+  private Attributes otelAttributesFrom(SplitReadStreamRequest request) {
+    return Attributes.builder()
+        .put("bq.storage.split_read_stream_request.name", getFieldAsString(request.getName()))
+        .put(
+            "bq.storage.split_read_stream_request.serialized_size",
+            getFieldAsString(request.getSerializedSize()))
+        .put(
+            "bq.storage.split_read_stream_request.fraction",
+            getFieldAsString(request.getFraction()))
         .build();
   }
 }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadClient.java
@@ -131,7 +131,9 @@ public class BigQueryReadClient implements BackgroundResource {
     this.settings = settings;
     this.stub =
         EnhancedBigQueryReadStub.create(
-            settings.getTypedStubSettings(), settings.getReadRowsRetryAttemptListener());
+            settings.getTypedStubSettings(),
+            settings.getReadRowsRetryAttemptListener(),
+            settings.isOpenTelemetryEnabled());
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
@@ -241,14 +243,12 @@ public class BigQueryReadClient implements BackgroundResource {
               .setAttribute(
                   "bq.storage.read_session.request.parent", getFieldAsString(request.getParent()))
               .setAttribute(
-                  "bq.storage.read_session.request.max_stream_count",
-                  getFieldAsString(request.getMaxStreamCount()))
+                  "bq.storage.read_session.request.max_stream_count", request.getMaxStreamCount())
               .setAttribute(
                   "bq.storage.read_session.request.preferred_min_stream_count",
-                  getFieldAsString(request.getPreferredMinStreamCount()))
+                  request.getPreferredMinStreamCount())
               .setAttribute(
-                  "bq.storage.read_session.request.serialized_size",
-                  getFieldAsString(request.getSerializedSize()))
+                  "bq.storage.read_session.request.serialized_size", request.getSerializedSize())
               .setAllAttributes(otelAttributesFrom(request.getReadSession()))
               .startSpan();
     }
@@ -548,18 +548,14 @@ public class BigQueryReadClient implements BackgroundResource {
             "bq.storage.read_session.serialized_size",
             getFieldAsString(readSession.getSerializedSize()))
         .put("bq.storage.read_session.table", getFieldAsString(readSession.getTable()))
-        .put(
-            "bq.storage.read_session.estimated_row_count",
-            getFieldAsString(readSession.getEstimatedRowCount()))
+        .put("bq.storage.read_session.estimated_row_count", readSession.getEstimatedRowCount())
         .put(
             "bq.storage.read_session.estimated_total_bytes_scanned",
-            getFieldAsString(readSession.getEstimatedTotalBytesScanned()))
+            readSession.getEstimatedTotalBytesScanned())
         .put(
             "bq.storage.read_session.estimated_total_physical_bytes",
-            getFieldAsString(readSession.getEstimatedTotalPhysicalFileSize()))
-        .put(
-            "bq.storage.read_session.streams_count",
-            getFieldAsString(readSession.getStreamsCount()))
+            readSession.getEstimatedTotalPhysicalFileSize())
+        .put("bq.storage.read_session.streams_count", readSession.getStreamsCount())
         .put("bq.storage.read_session.trace_id", getFieldAsString(readSession.getTraceId()))
         .put("bq.storage.read_session.expire_time", getFieldAsString(readSession.getExpireTime()))
         .build();

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadSettings.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadSettings.java
@@ -29,6 +29,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStubSettings;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.opentelemetry.api.trace.Tracer;
 import java.io.IOException;
 import java.util.List;
 
@@ -76,6 +77,8 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
   }
 
   private RetryAttemptListener readRowsRetryAttemptListener = null;
+  private boolean enableOpenTelemetryTracing = false;
+  private Tracer openTelemetryTracer = null;
 
   /**
    * If a non null readRowsRetryAttemptListener is provided, client will call onRetryAttempt
@@ -87,8 +90,24 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
     this.readRowsRetryAttemptListener = readRowsRetryAttemptListener;
   }
 
+  public void setEnableOpenTelemetryTracing(boolean enableOpenTelemetryTracing) {
+    this.enableOpenTelemetryTracing = enableOpenTelemetryTracing;
+    if (enableOpenTelemetryTracing) {
+      this.openTelemetryTracer = Singletons.getOpenTelemetry().getTracerProvider()
+          .tracerBuilder("com.google.cloud.bigquery.storage.v1.read")
+          .build();
+    }
+  }
   public RetryAttemptListener getReadRowsRetryAttemptListener() {
     return readRowsRetryAttemptListener;
+  }
+
+  public boolean isOpenTelemetryEnabled() {
+    return this.enableOpenTelemetryTracing;
+  }
+
+  public Tracer getOpenTelemetryTracer() {
+    return this.openTelemetryTracer;
   }
 
   /** Returns the object with the settings used for calls to splitReadStream. */
@@ -199,10 +218,16 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
     }
 
     private RetryAttemptListener readRowsRetryAttemptListener = null;
+    private boolean enableOpenTelemetryTracing = false;
 
     public Builder setReadRowsRetryAttemptListener(
         RetryAttemptListener readRowsRetryAttemptListener) {
       this.readRowsRetryAttemptListener = readRowsRetryAttemptListener;
+      return this;
+    }
+
+    public Builder setEnableOpenTelemetryTracing(boolean enableOpenTelemetryTracing) {
+      this.enableOpenTelemetryTracing = enableOpenTelemetryTracing;
       return this;
     }
 
@@ -228,6 +253,7 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
     public BigQueryReadSettings build() throws IOException {
       BigQueryReadSettings settings = new BigQueryReadSettings(this);
       settings.setReadRowsRetryAttemptListener(readRowsRetryAttemptListener);
+      settings.setEnableOpenTelemetryTracing(enableOpenTelemetryTracing);
       return settings;
     }
   }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadSettings.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQueryReadSettings.java
@@ -93,11 +93,14 @@ public class BigQueryReadSettings extends ClientSettings<BigQueryReadSettings> {
   public void setEnableOpenTelemetryTracing(boolean enableOpenTelemetryTracing) {
     this.enableOpenTelemetryTracing = enableOpenTelemetryTracing;
     if (enableOpenTelemetryTracing) {
-      this.openTelemetryTracer = Singletons.getOpenTelemetry().getTracerProvider()
-          .tracerBuilder("com.google.cloud.bigquery.storage.v1.read")
-          .build();
+      this.openTelemetryTracer =
+          Singletons.getOpenTelemetry()
+              .getTracerProvider()
+              .tracerBuilder("com.google.cloud.bigquery.storage.v1.read")
+              .build();
     }
   }
+
   public RetryAttemptListener getReadRowsRetryAttemptListener() {
     return readRowsRetryAttemptListener;
   }

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Singletons.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/Singletons.java
@@ -20,14 +20,14 @@ import io.opentelemetry.api.OpenTelemetry;
 import java.util.logging.Logger;
 
 /** Container for global singleton objects. */
-class Singletons {
+public class Singletons {
 
   private static final Logger log = Logger.getLogger(Singletons.class.getName());
 
   // Global OpenTelemetry instance
   private static OpenTelemetry openTelemetry = null;
 
-  static OpenTelemetry getOpenTelemetry() {
+  public static OpenTelemetry getOpenTelemetry() {
     if (openTelemetry == null) {
       openTelemetry = GlobalOpenTelemetry.get();
       log.info("BigQueryStorage initialized Open Telemetry");

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStub.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStub.java
@@ -36,12 +36,12 @@ import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.Singletons;
 import com.google.cloud.bigquery.storage.v1.SplitReadStreamRequest;
 import com.google.cloud.bigquery.storage.v1.SplitReadStreamResponse;
 import com.google.cloud.bigquery.storage.v1.stub.readrows.ApiResultRetryAlgorithm;
 import com.google.cloud.bigquery.storage.v1.stub.readrows.ReadRowsRetryingCallable;
 import com.google.common.collect.ImmutableMap;
-import com.google.cloud.bigquery.storage.v1.Singletons;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
@@ -114,7 +114,11 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
     ClientContext clientContext = ClientContext.create(baseSettings);
     GrpcBigQueryReadStub stub = new GrpcBigQueryReadStub(baseSettings, clientContext);
     return new EnhancedBigQueryReadStub(
-        stub, baseSettings, readRowsRetryAttemptListener, clientContext, enableOpenTelemetryTracing);
+        stub,
+        baseSettings,
+        readRowsRetryAttemptListener,
+        clientContext,
+        enableOpenTelemetryTracing);
   }
 
   @InternalApi("Visible for testing")
@@ -130,20 +134,25 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
     this.context = context;
     this.enableOpenTelemetryTracing = enableOpenTelemetryTracing;
     if (enableOpenTelemetryTracing) {
-      this.openTelemetryTracer = Singletons.getOpenTelemetry().getTracerProvider()
-          .tracerBuilder("com.google.cloud.bigquery.storage.v1.read.stub")
-          .build();
+      this.openTelemetryTracer =
+          Singletons.getOpenTelemetry()
+              .getTracerProvider()
+              .tracerBuilder("com.google.cloud.bigquery.storage.v1.read.stub")
+              .build();
     }
   }
 
   public UnaryCallable<CreateReadSessionRequest, ReadSession> createReadSessionCallable() {
     Span createReadSessionCallable = null;
     if (enableOpenTelemetryTracing) {
-      createReadSessionCallable = openTelemetryTracer
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.createReadSessionCallable")
-          .startSpan();
+      createReadSessionCallable =
+          openTelemetryTracer
+              .spanBuilder(
+                  "com.google.cloud.bigquery.storage.v1.read.stub.createReadSessionCallable")
+              .startSpan();
     }
-    try (Scope createReadSessionCallableScope = createReadSessionCallable != null ? createReadSessionCallable.makeCurrent() : null) {
+    try (Scope createReadSessionCallableScope =
+        createReadSessionCallable != null ? createReadSessionCallable.makeCurrent() : null) {
       return stub.createReadSessionCallable();
     } finally {
       if (createReadSessionCallable != null) {
@@ -155,11 +164,13 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   public ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable() {
     Span readRowsCallable = null;
     if (enableOpenTelemetryTracing) {
-      readRowsCallable = openTelemetryTracer
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.readRowsCallable")
-          .startSpan();
+      readRowsCallable =
+          openTelemetryTracer
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.readRowsCallable")
+              .startSpan();
     }
-    try (Scope readRowsCallableScope = readRowsCallable != null ? readRowsCallable.makeCurrent() : null) {
+    try (Scope readRowsCallableScope =
+        readRowsCallable != null ? readRowsCallable.makeCurrent() : null) {
       ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> innerCallable =
           GrpcRawCallableFactory.createServerStreamingCallable(
               GrpcCallSettings.<ReadRowsRequest, ReadRowsResponse>newBuilder()
@@ -212,11 +223,13 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   public UnaryCallable<SplitReadStreamRequest, SplitReadStreamResponse> splitReadStreamCallable() {
     Span splitReadStreamCallable = null;
     if (enableOpenTelemetryTracing) {
-      splitReadStreamCallable = openTelemetryTracer
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.splitReadStreamCallable")
-          .startSpan();
+      splitReadStreamCallable =
+          openTelemetryTracer
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.splitReadStreamCallable")
+              .startSpan();
     }
-    try (Scope readRowsCallableScope = splitReadStreamCallable != null ? splitReadStreamCallable.makeCurrent() : null) {
+    try (Scope readRowsCallableScope =
+        splitReadStreamCallable != null ? splitReadStreamCallable.makeCurrent() : null) {
       return stub.splitReadStreamCallable();
     } finally {
       if (splitReadStreamCallable != null) {
@@ -229,9 +242,10 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   public void close() {
     Span close = null;
     if (enableOpenTelemetryTracing) {
-      close = openTelemetryTracer
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.close")
-          .startSpan();
+      close =
+          openTelemetryTracer
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.close")
+              .startSpan();
     }
     try (Scope closeScope = close != null ? close.makeCurrent() : null) {
       stub.close();
@@ -246,9 +260,10 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   public void shutdown() {
     Span shutdown = null;
     if (enableOpenTelemetryTracing) {
-      shutdown = openTelemetryTracer
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.shutdown")
-          .startSpan();
+      shutdown =
+          openTelemetryTracer
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.shutdown")
+              .startSpan();
     }
     try (Scope shutdownScope = shutdown != null ? shutdown.makeCurrent() : null) {
       stub.shutdown();
@@ -273,9 +288,10 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   public void shutdownNow() {
     Span shutdownNow = null;
     if (enableOpenTelemetryTracing) {
-      shutdownNow = openTelemetryTracer
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.shutdownNow")
-          .startSpan();
+      shutdownNow =
+          openTelemetryTracer
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.shutdownNow")
+              .startSpan();
     }
     try (Scope shutdownNowScope = shutdownNow != null ? shutdownNow.makeCurrent() : null) {
       stub.shutdownNow();
@@ -290,13 +306,15 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
     Span awaitTermination = null;
     if (enableOpenTelemetryTracing) {
-      awaitTermination = openTelemetryTracer
-          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.awaitTermination")
-          .setAttribute("duration", duration)
-          .setAttribute("unit", unit.toString())
-          .startSpan();
+      awaitTermination =
+          openTelemetryTracer
+              .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.awaitTermination")
+              .setAttribute("duration", duration)
+              .setAttribute("unit", unit.toString())
+              .startSpan();
     }
-    try (Scope awaitTerminationScope = awaitTermination != null ? awaitTermination.makeCurrent() : null) {
+    try (Scope awaitTerminationScope =
+        awaitTermination != null ? awaitTermination.makeCurrent() : null) {
       return stub.awaitTermination(duration, unit);
     } finally {
       if (awaitTermination != null) {

--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStub.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStub.java
@@ -41,6 +41,10 @@ import com.google.cloud.bigquery.storage.v1.SplitReadStreamResponse;
 import com.google.cloud.bigquery.storage.v1.stub.readrows.ApiResultRetryAlgorithm;
 import com.google.cloud.bigquery.storage.v1.stub.readrows.ReadRowsRetryingCallable;
 import com.google.common.collect.ImmutableMap;
+import com.google.cloud.bigquery.storage.v1.Singletons;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +61,8 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   private final BigQueryReadStubSettings stubSettings;
   private final BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener;
   private final ClientContext context;
+  private boolean enableOpenTelemetryTracing = false;
+  private Tracer openTelemetryTracer = null;
 
   public static EnhancedBigQueryReadStub create(EnhancedBigQueryReadStubSettings settings)
       throws IOException {
@@ -66,6 +72,14 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
   public static EnhancedBigQueryReadStub create(
       EnhancedBigQueryReadStubSettings settings,
       BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener)
+      throws IOException {
+    return create(settings, readRowsRetryAttemptListener, false);
+  }
+
+  public static EnhancedBigQueryReadStub create(
+      EnhancedBigQueryReadStubSettings settings,
+      BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener,
+      boolean enableOpenTelemetryTracing)
       throws IOException {
     // Configure the base settings.
     BigQueryReadStubSettings.Builder baseSettingsBuilder =
@@ -100,7 +114,7 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
     ClientContext clientContext = ClientContext.create(baseSettings);
     GrpcBigQueryReadStub stub = new GrpcBigQueryReadStub(baseSettings, clientContext);
     return new EnhancedBigQueryReadStub(
-        stub, baseSettings, readRowsRetryAttemptListener, clientContext);
+        stub, baseSettings, readRowsRetryAttemptListener, clientContext, enableOpenTelemetryTracing);
   }
 
   @InternalApi("Visible for testing")
@@ -108,74 +122,141 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
       GrpcBigQueryReadStub stub,
       BigQueryReadStubSettings stubSettings,
       BigQueryReadSettings.RetryAttemptListener readRowsRetryAttemptListener,
-      ClientContext context) {
+      ClientContext context,
+      boolean enableOpenTelemetryTracing) {
     this.stub = stub;
     this.stubSettings = stubSettings;
     this.readRowsRetryAttemptListener = readRowsRetryAttemptListener;
     this.context = context;
+    this.enableOpenTelemetryTracing = enableOpenTelemetryTracing;
+    if (enableOpenTelemetryTracing) {
+      this.openTelemetryTracer = Singletons.getOpenTelemetry().getTracerProvider()
+          .tracerBuilder("com.google.cloud.bigquery.storage.v1.read.stub")
+          .build();
+    }
   }
 
   public UnaryCallable<CreateReadSessionRequest, ReadSession> createReadSessionCallable() {
-    return stub.createReadSessionCallable();
+    Span createReadSessionCallable = null;
+    if (enableOpenTelemetryTracing) {
+      createReadSessionCallable = openTelemetryTracer
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.createReadSessionCallable")
+          .startSpan();
+    }
+    try (Scope createReadSessionCallableScope = createReadSessionCallable != null ? createReadSessionCallable.makeCurrent() : null) {
+      return stub.createReadSessionCallable();
+    } finally {
+      if (createReadSessionCallable != null) {
+        createReadSessionCallable.end();
+      }
+    }
   }
 
   public ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable() {
-    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> innerCallable =
-        GrpcRawCallableFactory.createServerStreamingCallable(
-            GrpcCallSettings.<ReadRowsRequest, ReadRowsResponse>newBuilder()
-                .setMethodDescriptor(BigQueryReadGrpc.getReadRowsMethod())
-                .setParamsExtractor(
-                    new RequestParamsExtractor<ReadRowsRequest>() {
-                      @Override
-                      public Map<String, String> extract(ReadRowsRequest request) {
-                        return ImmutableMap.of(
-                            "read_stream", String.valueOf(request.getReadStream()));
-                      }
-                    })
-                .build(),
-            stubSettings.readRowsSettings().getRetryableCodes());
-    ServerStreamingCallSettings<ReadRowsRequest, ReadRowsResponse> callSettings =
-        stubSettings.readRowsSettings();
-
-    StreamingRetryAlgorithm<Void> retryAlgorithm =
-        new StreamingRetryAlgorithm<>(
-            new ApiResultRetryAlgorithm<Void>(readRowsRetryAttemptListener),
-            new ExponentialRetryAlgorithm(callSettings.getRetrySettings(), context.getClock()));
-
-    ScheduledRetryingExecutor<Void> retryingExecutor =
-        new ScheduledRetryingExecutor<>(retryAlgorithm, context.getExecutor());
-
-    if (context.getStreamWatchdog() != null) {
-      innerCallable = Callables.watched(innerCallable, callSettings, context);
+    Span readRowsCallable = null;
+    if (enableOpenTelemetryTracing) {
+      readRowsCallable = openTelemetryTracer
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.readRowsCallable")
+          .startSpan();
     }
+    try (Scope readRowsCallableScope = readRowsCallable != null ? readRowsCallable.makeCurrent() : null) {
+      ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> innerCallable =
+          GrpcRawCallableFactory.createServerStreamingCallable(
+              GrpcCallSettings.<ReadRowsRequest, ReadRowsResponse>newBuilder()
+                  .setMethodDescriptor(BigQueryReadGrpc.getReadRowsMethod())
+                  .setParamsExtractor(
+                      new RequestParamsExtractor<ReadRowsRequest>() {
+                        @Override
+                        public Map<String, String> extract(ReadRowsRequest request) {
+                          return ImmutableMap.of(
+                              "read_stream", String.valueOf(request.getReadStream()));
+                        }
+                      })
+                  .build(),
+              stubSettings.readRowsSettings().getRetryableCodes());
+      ServerStreamingCallSettings<ReadRowsRequest, ReadRowsResponse> callSettings =
+          stubSettings.readRowsSettings();
 
-    ReadRowsRetryingCallable outerCallable =
-        new ReadRowsRetryingCallable(
-            context.getDefaultCallContext(),
-            innerCallable,
-            retryingExecutor,
-            callSettings.getResumptionStrategy());
+      StreamingRetryAlgorithm<Void> retryAlgorithm =
+          new StreamingRetryAlgorithm<>(
+              new ApiResultRetryAlgorithm<Void>(readRowsRetryAttemptListener),
+              new ExponentialRetryAlgorithm(callSettings.getRetrySettings(), context.getClock()));
 
-    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> traced =
-        new TracedServerStreamingCallable<>(
-            outerCallable,
-            context.getTracerFactory(),
-            SpanName.of(TRACING_OUTER_CLIENT_NAME, "ReadRows"));
-    return traced.withDefaultCallContext(context.getDefaultCallContext());
+      ScheduledRetryingExecutor<Void> retryingExecutor =
+          new ScheduledRetryingExecutor<>(retryAlgorithm, context.getExecutor());
+
+      if (context.getStreamWatchdog() != null) {
+        innerCallable = Callables.watched(innerCallable, callSettings, context);
+      }
+
+      ReadRowsRetryingCallable outerCallable =
+          new ReadRowsRetryingCallable(
+              context.getDefaultCallContext(),
+              innerCallable,
+              retryingExecutor,
+              callSettings.getResumptionStrategy());
+
+      ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> traced =
+          new TracedServerStreamingCallable<>(
+              outerCallable,
+              context.getTracerFactory(),
+              SpanName.of(TRACING_OUTER_CLIENT_NAME, "ReadRows"));
+      return traced.withDefaultCallContext(context.getDefaultCallContext());
+    } finally {
+      if (readRowsCallable != null) {
+        readRowsCallable.end();
+      }
+    }
   }
 
   public UnaryCallable<SplitReadStreamRequest, SplitReadStreamResponse> splitReadStreamCallable() {
-    return stub.splitReadStreamCallable();
+    Span splitReadStreamCallable = null;
+    if (enableOpenTelemetryTracing) {
+      splitReadStreamCallable = openTelemetryTracer
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.splitReadStreamCallable")
+          .startSpan();
+    }
+    try (Scope readRowsCallableScope = splitReadStreamCallable != null ? splitReadStreamCallable.makeCurrent() : null) {
+      return stub.splitReadStreamCallable();
+    } finally {
+      if (splitReadStreamCallable != null) {
+        splitReadStreamCallable.end();
+      }
+    }
   }
 
   @Override
   public void close() {
-    stub.close();
+    Span close = null;
+    if (enableOpenTelemetryTracing) {
+      close = openTelemetryTracer
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.close")
+          .startSpan();
+    }
+    try (Scope closeScope = close != null ? close.makeCurrent() : null) {
+      stub.close();
+    } finally {
+      if (close != null) {
+        close.end();
+      }
+    }
   }
 
   @Override
   public void shutdown() {
-    stub.shutdown();
+    Span shutdown = null;
+    if (enableOpenTelemetryTracing) {
+      shutdown = openTelemetryTracer
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.shutdown")
+          .startSpan();
+    }
+    try (Scope shutdownScope = shutdown != null ? shutdown.makeCurrent() : null) {
+      stub.shutdown();
+    } finally {
+      if (shutdown != null) {
+        shutdown.end();
+      }
+    }
   }
 
   @Override
@@ -190,12 +271,38 @@ public class EnhancedBigQueryReadStub implements BackgroundResource {
 
   @Override
   public void shutdownNow() {
-    stub.shutdownNow();
+    Span shutdownNow = null;
+    if (enableOpenTelemetryTracing) {
+      shutdownNow = openTelemetryTracer
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.shutdownNow")
+          .startSpan();
+    }
+    try (Scope shutdownNowScope = shutdownNow != null ? shutdownNow.makeCurrent() : null) {
+      stub.shutdownNow();
+    } finally {
+      if (shutdownNow != null) {
+        shutdownNow.end();
+      }
+    }
   }
 
   @Override
   public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
-    return stub.awaitTermination(duration, unit);
+    Span awaitTermination = null;
+    if (enableOpenTelemetryTracing) {
+      awaitTermination = openTelemetryTracer
+          .spanBuilder("com.google.cloud.bigquery.storage.v1.read.stub.awaitTermination")
+          .setAttribute("duration", duration)
+          .setAttribute("unit", unit.toString())
+          .startSpan();
+    }
+    try (Scope awaitTerminationScope = awaitTermination != null ? awaitTermination.makeCurrent() : null) {
+      return stub.awaitTermination(duration, unit);
+    } finally {
+      if (awaitTermination != null) {
+        awaitTermination.end();
+      }
+    }
   }
 
   public BigQueryReadStubSettings getStubSettings() {

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
@@ -464,7 +464,6 @@ public class ITBigQueryStorageTest {
                   .build())
           .build();
 
-  private static OpenTelemetry otel;
   private static final Map<String, Map<AttributeKey<?>, Object>> OTEL_ATTRIBUTES =
       new HashMap<String, Map<AttributeKey<?>, Object>>();
   private static final Map<String, String> OTEL_PARENT_SPAN_IDS = new HashMap<>();
@@ -500,12 +499,6 @@ public class ITBigQueryStorageTest {
     client = BigQueryReadClient.create();
     projectName = ServiceOptions.getDefaultProjectId();
     parentProjectId = String.format("projects/%s", projectName);
-    SdkTracerProvider tracerProvider =
-        SdkTracerProvider.builder()
-            .addSpanProcessor(SimpleSpanProcessor.create(new TestSpanExporter()))
-            .setSampler(Sampler.alwaysOn())
-            .build();
-    otel = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
 
     LOG.info(
         String.format(
@@ -1600,6 +1593,14 @@ public class ITBigQueryStorageTest {
 
   @Test
   public void testSimpleReadWithOtelTracing() throws IOException {
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(new TestSpanExporter()))
+            .setSampler(Sampler.alwaysOn())
+            .build();
+    OpenTelemetry otel =
+        OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
+
     BigQueryReadSettings otelSettings =
         BigQueryReadSettings.newBuilder().setEnableOpenTelemetryTracing(true).build();
     BigQueryReadClient otelClient = BigQueryReadClient.create(otelSettings);

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
@@ -1632,7 +1632,26 @@ public class ITBigQueryStorageTest {
     assertNotNull(
         OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.createReadSession"));
     assertNotNull(
+        OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.createReadSessionCallable"));
+    assertNotNull(
+        OTEL_ATTRIBUTES.get(
+            "com.google.cloud.bigquery.storage.v1.read.stub.createReadSessionCallable"));
+    assertNotNull(
         OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.readRowsCallable"));
+    assertNotNull(
+        OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.stub.readRowsCallable"));
+
+    // createReadSession is the parent span of createReadSessionCallable
+    assertEquals(
+        OTEL_SPAN_IDS_TO_NAMES.get(
+            OTEL_PARENT_SPAN_IDS.get(
+                "com.google.cloud.bigquery.storage.v1.read.createReadSessionCallable")),
+        "com.google.cloud.bigquery.storage.v1.read.createReadSession");
+    assertEquals(
+        OTEL_ATTRIBUTES
+            .get("com.google.cloud.bigquery.storage.v1.read.createReadSession")
+            .get("bq.storage.read_session.request.max_stream_count"),
+        1);
     client.disableOpenTelemetryTracing();
   }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -76,6 +77,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Timestamp;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,9 +99,12 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalTypes;
@@ -453,11 +465,49 @@ public class ITBigQueryStorageTest {
                   .build())
           .build();
 
+  private static OpenTelemetry otel;
+  private static final Map<String, Map<AttributeKey<?>, Object>> OTEL_ATTRIBUTES =
+      new HashMap<String, Map<AttributeKey<?>, Object>>();
+  private static final Map<String, String> OTEL_PARENT_SPAN_IDS = new HashMap<>();
+  private static final Map<String, String> OTEL_SPAN_IDS_TO_NAMES = new HashMap<>();
+  private static final String OTEL_PARENT_SPAN_ID = "0000000000000000";
+
+  private static class TestSpanExporter implements io.opentelemetry.sdk.trace.export.SpanExporter {
+    @Override
+    public CompletableResultCode export(Collection<SpanData> collection) {
+      if (collection.isEmpty()) {
+        return CompletableResultCode.ofFailure();
+      }
+      for (SpanData data : collection) {
+        OTEL_ATTRIBUTES.put(data.getName(), data.getAttributes().asMap());
+        OTEL_PARENT_SPAN_IDS.put(data.getName(), data.getParentSpanId());
+        OTEL_SPAN_IDS_TO_NAMES.put(data.getSpanId(), data.getName());
+      }
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+      return CompletableResultCode.ofSuccess();
+    }
+  }
+
   @BeforeClass
   public static void beforeClass() throws IOException {
     client = BigQueryReadClient.create();
     projectName = ServiceOptions.getDefaultProjectId();
     parentProjectId = String.format("projects/%s", projectName);
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(new TestSpanExporter()))
+            .setSampler(Sampler.alwaysOn())
+            .build();
+    otel = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
 
     LOG.info(
         String.format(
@@ -1548,6 +1598,41 @@ public class ITBigQueryStorageTest {
 
     assertEquals(164_656, rowCount);
     localClient.close();
+  }
+
+  @Test
+  public void testSimpleReadWithOtelTracing() {
+    client.enableOpenTelemetryTracing();
+    String table =
+        BigQueryResource.FormatTableResource(
+            /* projectId= */ "bigquery-public-data",
+            /* datasetId= */ "samples",
+            /* tableId= */ "shakespeare");
+
+    ReadSession session =
+        client.createReadSession(
+            /* parent= */ parentProjectId,
+            /* readSession= */ ReadSession.newBuilder()
+                .setTable(table)
+                .setDataFormat(DataFormat.AVRO)
+                .build(),
+            /* maxStreamCount= */ 1);
+    assertEquals(
+        String.format(
+            "Did not receive expected number of streams for table '%s' CreateReadSession"
+                + " response:%n%s",
+            table, session.toString()),
+        1,
+        session.getStreamsCount());
+
+    ReadRowsRequest readRowsRequest =
+        ReadRowsRequest.newBuilder().setReadStream(session.getStreams(0).getName()).build();
+
+    ServerStream<ReadRowsResponse> stream = client.readRowsCallable().call(readRowsRequest);
+
+    assertNotNull(OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.createReadSession"));
+    assertNotNull(OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.readRowsCallable"));
+    client.disableOpenTelemetryTracing();
   }
 
   public void testUniverseDomain() throws IOException {

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -1630,8 +1629,10 @@ public class ITBigQueryStorageTest {
 
     ServerStream<ReadRowsResponse> stream = client.readRowsCallable().call(readRowsRequest);
 
-    assertNotNull(OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.createReadSession"));
-    assertNotNull(OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.readRowsCallable"));
+    assertNotNull(
+        OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.createReadSession"));
+    assertNotNull(
+        OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.storage.v1.read.readRowsCallable"));
     client.disableOpenTelemetryTracing();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.50.0</version>
+        <version>1.48.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This PR adds OpenTelemetry tracing support to the BigQueryReadClient and the BigQueryEnhancedReadStub. Tracing is toggled with a boolean flag and is enabled through the BigQueryReadSettings when creating the BigQueryReadClient.
