### PR TITLE
ci: remove unnecessary nexus-staging-maven-plugin declaration

### DIFF
--- a/google-cloud-bigquerystorage-bom/pom.xml
+++ b/google-cloud-bigquerystorage-bom/pom.xml
@@ -116,18 +116,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.7.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-          <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
The nexus-staging-maven-plugin is already declared in the parent
pom.xml:
https://github.com/googleapis/java-shared-config/blob/main/native-image-shared-config/pom.xml#L112
This parent POM uses a profile to control the activation of the plugin.

Redeclaring the plugin in google-cloud-bigquerystorage-bom/pom.xml causes problem in controlling the plugin activation by the profile.

b/422136872
