### PR TITLE
fix: StreamWriter message typo

### DIFF
--- a/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
+++ b/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamWriter.java
@@ -293,7 +293,7 @@ public class StreamWriter implements AutoCloseable {
                   String fetchedLocation = writeStream.getLocation();
                   log.info(
                       String.format(
-                          "Fethed location %s for stream name %s, extracted project and dataset"
+                          "Fetched location %s for stream name %s, extracted project and dataset"
                               + " name: %s\"",
                           fetchedLocation, streamName, datasetAndProjectName));
                   return fetchedLocation;


### PR DESCRIPTION
I see this typo hundreds of thousands of times a week in our logs.