### PR TITLE
deps: remove version declaration of gson and open-telemetry-bom

### DIFF
--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -120,7 +120,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -140,13 +140,6 @@
         <artifactId>json</artifactId>
         <version>20250517</version>
       </dependency>
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>1.51.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
 
       <!-- Test dependencies -->
       <dependency>


### PR DESCRIPTION
It's better to centrally manage these dependency versions.

- opentelemetry-bom is declared in https://github.com/googleapis/sdk-platform-java/blob/71da6c077d745d4c248eb122fcf9920ee0df772f/java-shared-dependencies/third-party-dependencies/pom.xml#L145
- gson is declared in https://github.com/googleapis/sdk-platform-java/blob/71da6c077d745d4c248eb122fcf9920ee0df772f/gapic-generator-java-bom/pom.xml#L49
