### PR TITLE
chore: Preserve new class AppendFormats in .OwlBot-hermetic.yaml

### DIFF
--- a/.github/.OwlBot-hermetic.yaml
+++ b/.github/.OwlBot-hermetic.yaml
@@ -20,6 +20,7 @@ deep-preserve-regex:
 - "/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
 - "/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/SchemaAwareStreamWriter.java"
 - "/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/ToProtoConverter.java"
+- "/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/AppendFormats.java"
 - "/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/BigQuerySchemaUtil.java"
 - "/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/BigQuerySchemaUtilTest.java"
 - "/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ConnectionWorkerPoolTest.java"


### PR DESCRIPTION
AppendFormats was a new class introduced in https://github.com/googleapis/java-bigquerystorage/pull/3086, but it didn't get added to .OwlBot-hermetic.yaml, which caused the hermetic build process to remove it https://github.com/googleapis/java-bigquerystorage/pull/3087/commits/3fe14927f1dba14019d0197a4a756e82cde1807f and the release is blocked.

Configure it to be preserved now in .OwlBot-hermetic.yaml