### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -3,21 +3,21 @@ handleGHRelease: true
 releaseType: java-yoshi
 branches:
     - branch: java7
-    - releaseType: java-backport
-      branch: 2.4.x
-    - releaseType: java-backport
-      branch: 2.12.x
-    - releaseType: java-backport
-      branch: 2.25.x
-    - releaseType: java-backport
-      branch: 2.38.x
-    - releaseType: java-backport
-      branch: 2.47.x
-    - releaseType: java-backport
-      branch: 3.5.x
-    - releaseType: java-backport
-      branch: 3.11.x
-    - releaseType: java-backport
-      branch: 3.15.x
+    - branch: 2.4.x
+      releaseType: java-backport
+    - branch: 2.12.x
+      releaseType: java-backport
+    - branch: 2.25.x
+      releaseType: java-backport
+    - branch: 2.38.x
+      releaseType: java-backport
+    - branch: 2.47.x
+      releaseType: java-backport
+    - branch: 3.5.x
+      releaseType: java-backport
+    - branch: 3.11.x
+      releaseType: java-backport
+    - branch: 3.15.x
+      releaseType: java-backport
     - branch: protobuf-4.x-rc
       manifest: true

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,44 +2,22 @@ bumpMinorPreMajor: true
 handleGHRelease: true
 releaseType: java-yoshi
 branches:
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-yoshi
-    branch: java7
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 2.4.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 2.12.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 2.25.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 2.38.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 2.47.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 3.5.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 3.11.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 3.15.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-yoshi
-    branch: protobuf-4.x-rc
-    manifest: true
+    - branch: java7
+    - releaseType: java-backport
+      branch: 2.4.x
+    - releaseType: java-backport
+      branch: 2.12.x
+    - releaseType: java-backport
+      branch: 2.25.x
+    - releaseType: java-backport
+      branch: 2.38.x
+    - releaseType: java-backport
+      branch: 2.47.x
+    - releaseType: java-backport
+      branch: 3.5.x
+    - releaseType: java-backport
+      branch: 3.11.x
+    - releaseType: java-backport
+      branch: 3.15.x
+    - branch: protobuf-4.x-rc
+      manifest: true


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.