### PR TITLE
deps: Upgrade sdk-platform-java-config to 3.55.0-rc1

### DIFF
--- a/google-cloud-bigquerystorage-bom/pom.xml
+++ b/google-cloud-bigquerystorage-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>sdk-platform-java-config</artifactId>
-    <version>3.54.2</version>
+    <version>3.55.0-rc1</version>
   </parent>
 
   <name>Google Cloud bigquerystorage BOM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>sdk-platform-java-config</artifactId>
-    <version>3.54.2</version>
+    <version>3.55.0-rc1</version>
   </parent>
 
   <developers>


### PR DESCRIPTION
This upgrades brings in protobuf-java 4.33, which should resolve the compilation error in https://github.com/googleapis/java-bigquerystorage/pull/3151.