### PR TITLE
test: Add picosecond test cases

### DIFF
--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageReadClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageReadClientTest.java
@@ -535,7 +535,7 @@ public class ITBigQueryStorageReadClientTest {
                 .setMode(Mode.NULLABLE)
                 .build(),
             Field.newBuilder(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME, StandardSQLTypeName.TIMESTAMP)
-                .setTimestampPrecision(12L)
+                .setTimestampPrecision(Helper.PICOSECOND_PRECISION)
                 .setMode(Mode.NULLABLE)
                 .build());
 
@@ -557,7 +557,8 @@ public class ITBigQueryStorageReadClientTest {
             .addFields(
                 TableFieldSchema.newBuilder()
                     .setName(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME)
-                    .setTimestampPrecision(Int64Value.newBuilder().setValue(12).build())
+                    .setTimestampPrecision(
+                        Int64Value.newBuilder().setValue(Helper.PICOSECOND_PRECISION).build())
                     .setType(TableFieldSchema.Type.TIMESTAMP)
                     .setMode(TableFieldSchema.Mode.NULLABLE)
                     .build())

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageReadClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageReadClientTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.bigquery.storage.v1.it;
 
+import static com.google.cloud.bigquery.storage.v1.it.util.Helper.TIMESTAMP_COLUMN_NAME;
+import static com.google.cloud.bigquery.storage.v1.it.util.Helper.TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertArrayEquals;
@@ -53,6 +55,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadSettings;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
@@ -77,6 +80,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Int64Value;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -123,10 +127,8 @@ public class ITBigQueryStorageReadClientTest {
   private static final String DATASET = RemoteBigQueryHelper.generateDatasetName();
   private static final String DESCRIPTION = "BigQuery Storage Java client test dataset";
   private static final String BQSTORAGE_TIMESTAMP_READ_TABLE = "bqstorage_timestamp_read";
-
   private static final int SHAKESPEARE_SAMPLE_ROW_COUNT = 164_656;
   private static final int SHAKESPEARE_SAMPELS_ROWS_MORE_THAN_100_WORDS = 1_333;
-
   private static final int MAX_STREAM_COUNT = 1;
 
   private static BigQueryReadClient readClient;
@@ -526,43 +528,48 @@ public class ITBigQueryStorageReadClientTest {
 
   private static void setupTimestampTable()
       throws DescriptorValidationException, IOException, InterruptedException {
+    // Schema to create a BQ table
     com.google.cloud.bigquery.Schema timestampSchema =
         com.google.cloud.bigquery.Schema.of(
-            Field.newBuilder("timestamp", StandardSQLTypeName.TIMESTAMP)
+            Field.newBuilder(TIMESTAMP_COLUMN_NAME, StandardSQLTypeName.TIMESTAMP)
+                .setMode(Mode.NULLABLE)
+                .build(),
+            Field.newBuilder(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME, StandardSQLTypeName.TIMESTAMP)
+                .setTimestampPrecision(12L)
                 .setMode(Mode.NULLABLE)
                 .build());
 
+    // Create BQ table with timestamps
+    TableId tableId = TableId.of(DATASET, BQSTORAGE_TIMESTAMP_READ_TABLE);
+    bigquery.create(TableInfo.of(tableId, StandardTableDefinition.of(timestampSchema)));
+
+    TableName parentTable = TableName.of(projectName, DATASET, BQSTORAGE_TIMESTAMP_READ_TABLE);
+
+    // Define the BQStorage schema to write to
     TableSchema timestampTableSchema =
         TableSchema.newBuilder()
             .addFields(
                 TableFieldSchema.newBuilder()
-                    .setName("timestamp")
+                    .setName(TIMESTAMP_COLUMN_NAME)
+                    .setType(TableFieldSchema.Type.TIMESTAMP)
+                    .setMode(TableFieldSchema.Mode.NULLABLE)
+                    .build())
+            .addFields(
+                TableFieldSchema.newBuilder()
+                    .setName(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME)
+                    .setTimestampPrecision(Int64Value.newBuilder().setValue(12).build())
                     .setType(TableFieldSchema.Type.TIMESTAMP)
                     .setMode(TableFieldSchema.Mode.NULLABLE)
                     .build())
             .build();
 
-    // Create table with Range fields.
-    TableId tableId = TableId.of(DATASET, BQSTORAGE_TIMESTAMP_READ_TABLE);
-    bigquery.create(TableInfo.of(tableId, StandardTableDefinition.of(timestampSchema)));
-
-    TableName parentTable = TableName.of(projectName, DATASET, BQSTORAGE_TIMESTAMP_READ_TABLE);
-    RetrySettings retrySettings =
-        RetrySettings.newBuilder()
-            .setInitialRetryDelayDuration(Duration.ofMillis(500))
-            .setRetryDelayMultiplier(1.1)
-            .setMaxAttempts(5)
-            .setMaxRetryDelayDuration(Duration.ofSeconds(10))
-            .build();
-
     try (JsonStreamWriter writer =
-        JsonStreamWriter.newBuilder(parentTable.toString(), timestampTableSchema)
-            .setRetrySettings(retrySettings)
-            .build()) {
+        JsonStreamWriter.newBuilder(parentTable.toString(), timestampTableSchema).build()) {
       JSONArray data = new JSONArray();
-      for (long timestampMicro : Helper.INPUT_TIMESTAMPS_MICROS) {
+      for (Object[] timestampData : Helper.INPUT_TIMESTAMPS) {
         JSONObject row = new JSONObject();
-        row.put("timestamp", timestampMicro);
+        row.put(TIMESTAMP_COLUMN_NAME, timestampData[0]);
+        row.put(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME, timestampData[1]);
         data.put(row);
       }
 
@@ -858,6 +865,7 @@ public class ITBigQueryStorageReadClientTest {
     }
   }
 
+  // Tests that inputs for micros and picos can be read properly via Arrow
   @Test
   public void timestamp_readArrow() throws IOException {
     String table =
@@ -865,7 +873,21 @@ public class ITBigQueryStorageReadClientTest {
     ReadSession session =
         readClient.createReadSession(
             parentProjectId,
-            ReadSession.newBuilder().setTable(table).setDataFormat(DataFormat.ARROW).build(),
+            ReadSession.newBuilder()
+                .setTable(table)
+                .setDataFormat(DataFormat.ARROW)
+                .setReadOptions(
+                    TableReadOptions.newBuilder()
+                        .setArrowSerializationOptions(
+                            ArrowSerializationOptions.newBuilder()
+                                // This serialization option only impacts columns that are type
+                                // `TIMESTAMP_PICOS` and has no impact on other columns types
+                                .setPicosTimestampPrecision(
+                                    ArrowSerializationOptions.PicosTimestampPrecision
+                                        .TIMESTAMP_PRECISION_PICOS)
+                                .build())
+                        .build())
+                .build(),
             MAX_STREAM_COUNT);
     assertEquals(
         String.format(
@@ -896,22 +918,32 @@ public class ITBigQueryStorageReadClientTest {
         reader.processRows(
             response.getArrowRecordBatch(),
             new SimpleRowReaderArrow.ArrowTimestampBatchConsumer(
-                Arrays.asList(Helper.INPUT_TIMESTAMPS_MICROS)));
+                Helper.EXPECTED_TIMESTAMPS_HIGHER_PRECISION_ISO_OUTPUT));
         rowCount += response.getRowCount();
       }
-      assertEquals(Helper.EXPECTED_TIMESTAMPS_MICROS.length, rowCount);
+      assertEquals(Helper.EXPECTED_TIMESTAMPS_HIGHER_PRECISION_ISO_OUTPUT.length, rowCount);
     }
   }
 
+  // Tests that inputs for micros and picos can be read properly via Avro
   @Test
   public void timestamp_readAvro() throws IOException {
     String table =
         BigQueryResource.formatTableResource(projectName, DATASET, BQSTORAGE_TIMESTAMP_READ_TABLE);
     List<GenericData.Record> rows = Helper.readAllRows(readClient, parentProjectId, table, null);
     List<Long> timestamps =
-        rows.stream().map(x -> (Long) x.get("timestamp")).collect(Collectors.toList());
+        rows.stream().map(x -> (Long) x.get(TIMESTAMP_COLUMN_NAME)).collect(Collectors.toList());
+    List<String> timestampHigherPrecision =
+        rows.stream()
+            .map(x -> x.get(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME).toString())
+            .collect(Collectors.toList());
     for (int i = 0; i < timestamps.size(); i++) {
-      assertEquals(Helper.EXPECTED_TIMESTAMPS_MICROS[i], timestamps.get(i));
+      assertEquals(Helper.EXPECTED_TIMESTAMPS_HIGHER_PRECISION_ISO_OUTPUT[i][0], timestamps.get(i));
+    }
+    for (int i = 0; i < timestampHigherPrecision.size(); i++) {
+      assertEquals(
+          Helper.EXPECTED_TIMESTAMPS_HIGHER_PRECISION_ISO_OUTPUT[i][1],
+          timestampHigherPrecision.get(i));
     }
   }
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageWriteClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageWriteClientTest.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.bigquery.storage.v1.it;
 
+import static com.google.cloud.bigquery.storage.v1.it.util.Helper.EXPECTED_TIMESTAMPS_HIGHER_PRECISION_ISO_OUTPUT;
+import static com.google.cloud.bigquery.storage.v1.it.util.Helper.TIMESTAMP_COLUMN_NAME;
+import static com.google.cloud.bigquery.storage.v1.it.util.Helper.TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -25,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.util.Sleeper;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.HeaderProvider;
@@ -45,11 +49,13 @@ import com.google.cloud.bigquery.storage.v1.it.util.BigQueryResource;
 import com.google.cloud.bigquery.storage.v1.it.util.Helper;
 import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Int64Value;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import java.io.ByteArrayOutputStream;
@@ -115,6 +121,26 @@ public class ITBigQueryStorageWriteClientTest {
   private static BigQuery bigquery;
 
   private static final BufferAllocator allocator = new RootAllocator();
+
+  // Arrow is a bit special in that timestamps are limited to nanoseconds precision.
+  // The data will be padded to fit into the higher precision columns.
+  public static final Object[][] INPUT_ARROW_WRITE_TIMESTAMPS =
+      new Object[][] {
+        {1735734896123456L /* 2025-01-01T12:34:56.123456Z */, 1735734896123456789L},
+        {1580646896123456L /* 2020-02-02T12:34:56.123456Z */, 1580646896123456789L},
+        {636467696123456L /* 1990-03-03T12:34:56.123456Z */, 636467696123456789L},
+        {165846896123456L /* 1975-04-04T12:34:56.123456Z */, 165846896123456789L}
+      };
+
+  // Arrow's higher precision column is padded with extra 0's if configured to return
+  // ISO as output for any picosecond enabled column.
+  public static final Object[][] EXPECTED_ARROW_WRITE_TIMESTAMPS_ISO_OUTPUT =
+      new Object[][] {
+        {1735734896123456L /* 2025-01-01T12:34:56.123456Z */, "2025-01-01T12:34:56.123456789000Z"},
+        {1580646896123456L /* 2020-02-02T12:34:56.123456Z */, "2020-02-02T12:34:56.123456789000Z"},
+        {636467696123456L /* 1990-03-03T12:34:56.123456Z */, "1990-03-03T12:34:56.123456789000Z"},
+        {165846896123456L /* 1975-04-04T12:34:56.123456Z */, "1975-04-04T12:34:56.123456789000Z"}
+      };
 
   public static class StringWithSecondsNanos {
     public String foo;
@@ -2272,44 +2298,54 @@ public class ITBigQueryStorageWriteClientTest {
     }
   }
 
+  // Tests that inputs for micro and picos are able to use Arrow to write
+  // to BQ
   @Test
   public void timestamp_arrowWrite() throws IOException {
-    String timestampFieldName = "timestamp";
-    com.google.cloud.bigquery.Schema tableSchema =
-        com.google.cloud.bigquery.Schema.of(
-            Field.newBuilder(timestampFieldName, StandardSQLTypeName.TIMESTAMP)
-                .setMode(Mode.REQUIRED)
-                .build());
-
     String tableName = "bqstorage_timestamp_write_arrow";
-    TableId testTableId = TableId.of(DATASET, tableName);
-    bigquery.create(
-        TableInfo.of(
-            testTableId, StandardTableDefinition.newBuilder().setSchema(tableSchema).build()));
+    // Opt to create a new table to write to instead of re-using table to prevent
+    // the test from failing due to any issues with deleting data after test.
+    // Increases the test time duration, but would be more resilient to transient
+    // failures
+    createTimestampTable(tableName);
 
+    // Define the fields as Arrow types that are compatible with BQ Schema types
     List<org.apache.arrow.vector.types.pojo.Field> fields =
         ImmutableList.of(
             new org.apache.arrow.vector.types.pojo.Field(
-                timestampFieldName,
+                TIMESTAMP_COLUMN_NAME,
                 FieldType.nullable(
                     new ArrowType.Timestamp(
                         org.apache.arrow.vector.types.TimeUnit.MICROSECOND, "UTC")),
+                null),
+            new org.apache.arrow.vector.types.pojo.Field(
+                TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME,
+                FieldType.nullable(
+                    new ArrowType.Timestamp(
+                        org.apache.arrow.vector.types.TimeUnit.NANOSECOND, "UTC")),
                 null));
-    org.apache.arrow.vector.types.pojo.Schema schema =
+    org.apache.arrow.vector.types.pojo.Schema arrowSchema =
         new org.apache.arrow.vector.types.pojo.Schema(fields, null);
 
+    int numRows = INPUT_ARROW_WRITE_TIMESTAMPS.length;
     TableName parent = TableName.of(ServiceOptions.getDefaultProjectId(), DATASET, tableName);
     try (StreamWriter streamWriter =
-        StreamWriter.newBuilder(parent.toString() + "/_default").setWriterSchema(schema).build()) {
-      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        StreamWriter.newBuilder(parent.toString() + "/_default")
+            .setWriterSchema(arrowSchema)
+            .build()) {
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
         TimeStampMicroTZVector timestampVector =
-            (TimeStampMicroTZVector) root.getVector(timestampFieldName);
-        timestampVector.allocateNew(Helper.INPUT_TIMESTAMPS_MICROS.length);
+            (TimeStampMicroTZVector) root.getVector(TIMESTAMP_COLUMN_NAME);
+        TimeStampNanoTZVector timestampHigherPrecisionVector =
+            (TimeStampNanoTZVector) root.getVector(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME);
+        timestampVector.allocateNew(numRows);
+        timestampHigherPrecisionVector.allocateNew(numRows);
 
-        for (int i = 0; i < Helper.INPUT_TIMESTAMPS_MICROS.length; i++) {
-          timestampVector.set(i, Helper.INPUT_TIMESTAMPS_MICROS[i]);
+        for (int i = 0; i < numRows; i++) {
+          timestampVector.set(i, (Long) INPUT_ARROW_WRITE_TIMESTAMPS[i][0]);
+          timestampHigherPrecisionVector.set(i, (Long) INPUT_ARROW_WRITE_TIMESTAMPS[i][1]);
         }
-        root.setRowCount(Helper.INPUT_TIMESTAMPS_MICROS.length);
+        root.setRowCount(numRows);
 
         CompressionCodec codec =
             NoCompressionCodec.Factory.INSTANCE.createCodec(
@@ -2319,66 +2355,103 @@ public class ITBigQueryStorageWriteClientTest {
         org.apache.arrow.vector.ipc.message.ArrowRecordBatch batch =
             vectorUnloader.getRecordBatch();
         // Asynchronous append.
-        streamWriter.append(batch, -1);
+        ApiFuture<AppendRowsResponse> future = streamWriter.append(batch);
+        ApiFutures.addCallback(
+            future, new Helper.AppendCompleteCallback(), MoreExecutors.directExecutor());
       }
     }
-    String table =
-        BigQueryResource.formatTableResource(
-            ServiceOptions.getDefaultProjectId(), DATASET, tableName);
-    List<GenericData.Record> rows = Helper.readAllRows(readClient, parentProjectId, table, null);
-    List<Long> timestamps =
-        rows.stream().map(x -> (Long) x.get(timestampFieldName)).collect(Collectors.toList());
-    assertEquals(timestamps.size(), Helper.EXPECTED_TIMESTAMPS_MICROS.length);
-    for (int i = 0; i < timestamps.size(); i++) {
-      assertEquals(timestamps.get(i), Helper.EXPECTED_TIMESTAMPS_MICROS[i]);
-    }
+    assertTimestamps(tableName, EXPECTED_ARROW_WRITE_TIMESTAMPS_ISO_OUTPUT);
   }
 
+  // Tests that inputs for micro and picos are able to converted to protobuf
+  // and written to BQ
   @Test
   public void timestamp_protobufWrite()
       throws IOException, DescriptorValidationException, InterruptedException {
-    String timestampFieldName = "timestamp";
-    com.google.cloud.bigquery.Schema bqTableSchema =
-        com.google.cloud.bigquery.Schema.of(
-            Field.newBuilder(timestampFieldName, StandardSQLTypeName.TIMESTAMP)
-                .setMode(Mode.REQUIRED)
-                .build());
+    String tableName = "bqstorage_timestamp_write_protobuf";
+    // Opt to create a new table to write to instead of re-using table to prevent
+    // the test from failing due to any issues with deleting data after test.
+    // Increases the test time duration, but would be more resilient to transient
+    // failures
+    createTimestampTable(tableName);
 
-    String tableName = "bqstorage_timestamp_write_avro";
-    TableId testTableId = TableId.of(DATASET, tableName);
-    bigquery.create(
-        TableInfo.of(
-            testTableId, StandardTableDefinition.newBuilder().setSchema(bqTableSchema).build()));
-
-    TableFieldSchema TEST_TIMESTAMP =
+    // Define the table schema so that the automatic converter is able to
+    // determine how to convert from Json -> Protobuf
+    TableFieldSchema testTimestamp =
         TableFieldSchema.newBuilder()
-            .setName(timestampFieldName)
+            .setName(TIMESTAMP_COLUMN_NAME)
             .setType(TableFieldSchema.Type.TIMESTAMP)
             .setMode(TableFieldSchema.Mode.NULLABLE)
             .build();
-    TableSchema tableSchema = TableSchema.newBuilder().addFields(TEST_TIMESTAMP).build();
+    TableFieldSchema testTimestampHighPrecision =
+        TableFieldSchema.newBuilder()
+            .setName(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME)
+            .setTimestampPrecision(Int64Value.newBuilder().setValue(12).build())
+            .setType(TableFieldSchema.Type.TIMESTAMP)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .build();
+    TableSchema tableSchema =
+        TableSchema.newBuilder()
+            .addFields(testTimestamp)
+            .addFields(testTimestampHighPrecision)
+            .build();
 
     TableName parent = TableName.of(ServiceOptions.getDefaultProjectId(), DATASET, tableName);
     try (JsonStreamWriter jsonStreamWriter =
         JsonStreamWriter.newBuilder(parent.toString(), tableSchema).build()) {
-      for (long timestampMicro : Helper.INPUT_TIMESTAMPS_MICROS) {
-        JSONArray jsonArray = new JSONArray();
+      JSONArray jsonArray = new JSONArray();
+      for (Object[] timestampData : Helper.INPUT_TIMESTAMPS) {
         JSONObject row = new JSONObject();
-        row.put(timestampFieldName, timestampMicro);
+        row.put(TIMESTAMP_COLUMN_NAME, timestampData[0]);
+        row.put(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME, timestampData[1]);
         jsonArray.put(row);
-        jsonStreamWriter.append(jsonArray);
       }
+      ApiFuture<AppendRowsResponse> future = jsonStreamWriter.append(jsonArray);
+      ApiFutures.addCallback(
+          future, new Helper.AppendCompleteCallback(), MoreExecutors.directExecutor());
     }
+    assertTimestamps(tableName, EXPECTED_TIMESTAMPS_HIGHER_PRECISION_ISO_OUTPUT);
+  }
 
+  private void createTimestampTable(String tableName) {
+    Schema bqTableSchema =
+        Schema.of(
+            Field.newBuilder(TIMESTAMP_COLUMN_NAME, StandardSQLTypeName.TIMESTAMP)
+                .setMode(Mode.NULLABLE)
+                .build(),
+            Field.newBuilder(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME, StandardSQLTypeName.TIMESTAMP)
+                .setMode(Mode.NULLABLE)
+                .setTimestampPrecision(12L)
+                .build());
+
+    TableId testTableId = TableId.of(DATASET, tableName);
+    bigquery.create(
+        TableInfo.of(
+            testTableId, StandardTableDefinition.newBuilder().setSchema(bqTableSchema).build()));
+  }
+
+  private void assertTimestamps(String tableName, Object[][] expected) throws IOException {
     String table =
         BigQueryResource.formatTableResource(
             ServiceOptions.getDefaultProjectId(), DATASET, tableName);
+
+    // Read all the data as Avro GenericRecords
     List<GenericData.Record> rows = Helper.readAllRows(readClient, parentProjectId, table, null);
+
+    // Each timestamp response is expected to contain two fields:
+    // 1. Micros from timestamp as a Long and 2. ISO8601 instant with picos precision
     List<Long> timestamps =
-        rows.stream().map(x -> (Long) x.get(timestampFieldName)).collect(Collectors.toList());
-    assertEquals(timestamps.size(), Helper.EXPECTED_TIMESTAMPS_MICROS.length);
-    for (int i = 0; i < timestamps.size(); i++) {
-      assertEquals(timestamps.get(i), Helper.EXPECTED_TIMESTAMPS_MICROS[i]);
+        rows.stream().map(x -> (Long) x.get(TIMESTAMP_COLUMN_NAME)).collect(Collectors.toList());
+    List<String> timestampHigherPrecision =
+        rows.stream()
+            .map(x -> x.get(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME).toString())
+            .collect(Collectors.toList());
+
+    assertEquals(timestamps.size(), expected.length);
+    assertEquals(timestampHigherPrecision.size(), expected.length);
+    for (int i = 0; i < timestampHigherPrecision.size(); i++) {
+      assertEquals(timestamps.get(i), expected[i][0]);
+      assertEquals(timestampHigherPrecision.get(i), expected[i][1]);
     }
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageWriteClientTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageWriteClientTest.java
@@ -2386,7 +2386,8 @@ public class ITBigQueryStorageWriteClientTest {
     TableFieldSchema testTimestampHighPrecision =
         TableFieldSchema.newBuilder()
             .setName(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME)
-            .setTimestampPrecision(Int64Value.newBuilder().setValue(12).build())
+            .setTimestampPrecision(
+                Int64Value.newBuilder().setValue(Helper.PICOSECOND_PRECISION).build())
             .setType(TableFieldSchema.Type.TIMESTAMP)
             .setMode(TableFieldSchema.Mode.NULLABLE)
             .build();
@@ -2399,6 +2400,9 @@ public class ITBigQueryStorageWriteClientTest {
     TableName parent = TableName.of(ServiceOptions.getDefaultProjectId(), DATASET, tableName);
     try (JsonStreamWriter jsonStreamWriter =
         JsonStreamWriter.newBuilder(parent.toString(), tableSchema).build()) {
+
+      // Creates a single payload to append (JsonArray with multiple JsonObjects)
+      // Each JsonObject contains a row (one micros, one picos)
       JSONArray jsonArray = new JSONArray();
       for (Object[] timestampData : Helper.INPUT_TIMESTAMPS) {
         JSONObject row = new JSONObject();
@@ -2421,7 +2425,7 @@ public class ITBigQueryStorageWriteClientTest {
                 .build(),
             Field.newBuilder(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME, StandardSQLTypeName.TIMESTAMP)
                 .setMode(Mode.NULLABLE)
-                .setTimestampPrecision(12L)
+                .setTimestampPrecision(Helper.PICOSECOND_PRECISION)
                 .build());
 
     TableId testTableId = TableId.of(DATASET, tableName);
@@ -2447,11 +2451,11 @@ public class ITBigQueryStorageWriteClientTest {
             .map(x -> x.get(TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME).toString())
             .collect(Collectors.toList());
 
-    assertEquals(timestamps.size(), expected.length);
-    assertEquals(timestampHigherPrecision.size(), expected.length);
+    assertEquals(expected.length, timestamps.size());
+    assertEquals(expected.length, timestampHigherPrecision.size());
     for (int i = 0; i < timestampHigherPrecision.size(); i++) {
-      assertEquals(timestamps.get(i), expected[i][0]);
-      assertEquals(timestampHigherPrecision.get(i), expected[i][1]);
+      assertEquals(expected[i][0], timestamps.get(i));
+      assertEquals(expected[i][1], timestampHigherPrecision.get(i));
     }
   }
 }

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/Helper.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/Helper.java
@@ -43,6 +43,7 @@ import org.apache.avro.generic.GenericRecordBuilder;
 
 public class Helper {
 
+  public static final long PICOSECOND_PRECISION = 12;
   public static final String TIMESTAMP_COLUMN_NAME = "timestamp";
   public static final String TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME = "timestampHigherPrecision";
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/Helper.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/Helper.java
@@ -23,6 +23,7 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.AvroSerializationOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
@@ -42,20 +43,27 @@ import org.apache.avro.generic.GenericRecordBuilder;
 
 public class Helper {
 
-  public static final Long[] INPUT_TIMESTAMPS_MICROS =
-      new Long[] {
-        1735734896123456L, // 2025-01-01T12:34:56.123456Z
-        1580646896123456L, // 2020-02-02T12:34:56.123456Z
-        636467696123456L, // 1990-03-03T12:34:56.123456Z
-        165846896123456L // 1975-04-04T12:34:56.123456Z
+  public static final String TIMESTAMP_COLUMN_NAME = "timestamp";
+  public static final String TIMESTAMP_HIGHER_PRECISION_COLUMN_NAME = "timestampHigherPrecision";
+
+  // Sample test cases for timestamps. First element is micros from epcoh and the second element
+  // is the ISO format in with picosecond precision
+  public static final Object[][] INPUT_TIMESTAMPS =
+      new Object[][] {
+        {1735734896123456L /* 2025-01-01T12:34:56.123456Z */, "2025-01-01T12:34:56.123456789123Z"},
+        {1580646896123456L /* 2020-02-02T12:34:56.123456Z */, "2020-02-02T12:34:56.123456789123Z"},
+        {636467696123456L /* 1990-03-03T12:34:56.123456Z */, "1990-03-03T12:34:56.123456789123Z"},
+        {165846896123456L /* 1975-04-04T12:34:56.123456Z */, "1975-04-04T12:34:56.123456789123Z"}
       };
 
-  public static final Long[] EXPECTED_TIMESTAMPS_MICROS =
-      new Long[] {
-        1735734896123456L, // 2025-01-01T12:34:56.123456Z
-        1580646896123456L, // 2020-02-02T12:34:56.123456Z
-        636467696123456L, // 1990-03-03T12:34:56.123456Z
-        165846896123456L // 1975-04-04T12:34:56.123456Z
+  // Expected response for timestamps from the input. If enabled with ISO as output, it will
+  // ISO8601 format for any picosecond enabled column.
+  public static final Object[][] EXPECTED_TIMESTAMPS_HIGHER_PRECISION_ISO_OUTPUT =
+      new Object[][] {
+        {1735734896123456L /* 2025-01-01T12:34:56.123456Z */, "2025-01-01T12:34:56.123456789123Z"},
+        {1580646896123456L /* 2020-02-02T12:34:56.123456Z */, "2020-02-02T12:34:56.123456789123Z"},
+        {636467696123456L /* 1990-03-03T12:34:56.123456Z */, "1990-03-03T12:34:56.123456789123Z"},
+        {165846896123456L /* 1975-04-04T12:34:56.123456Z */, "1975-04-04T12:34:56.123456789123Z"}
       };
 
   public static ServiceAccountCredentials loadCredentials(String credentialFile) {
@@ -114,7 +122,22 @@ public class Helper {
             .setParent(parentProjectId)
             .setMaxStreamCount(1)
             .setReadSession(
-                ReadSession.newBuilder().setTable(table).setDataFormat(DataFormat.AVRO).build());
+                ReadSession.newBuilder()
+                    .setTable(table)
+                    .setDataFormat(DataFormat.AVRO)
+                    .setReadOptions(
+                        ReadSession.TableReadOptions.newBuilder()
+                            .setAvroSerializationOptions(
+                                AvroSerializationOptions.newBuilder()
+                                    .setPicosTimestampPrecision(
+                                        // This serialization option only impacts columns that are
+                                        // type. `TIMESTAMP_PICOS` and has no impact on other
+                                        // columns types.
+                                        AvroSerializationOptions.PicosTimestampPrecision
+                                            .TIMESTAMP_PRECISION_PICOS)
+                                    .build())
+                            .build())
+                    .build());
 
     if (snapshotInMillis != null) {
       createSessionRequestBuilder


### PR DESCRIPTION
Builds off of part one in https://github.com/googleapis/java-bigquerystorage/pull/3156

Introduces test cases for timestamp picosecond columns for the Read and Write APIs