### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/api-bigquery is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/api-bigquery
+# The @googleapis/bigquery-team is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/bigquery-team
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -171,5 +171,5 @@ permissionRules:
     permission: admin
   - team: api-bigquerystorage
     permission: push
-  - team: yoshi-java
+  - team: cloud-sdk-java-team
     permission: push

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,7 +13,7 @@
   "api_id": "bigquerystorage.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/api-bigquery",
+  "codeowner_team": "@googleapis/bigquery-team",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
   "recommended_package": "com.google.cloud.bigquery.storage.v1"
 }

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -13,7 +13,7 @@ libraries:
       repo: googleapis/java-bigquerystorage
       repo_short: java-bigquerystorage
       distribution_name: com.google.cloud:google-cloud-bigquerystorage
-      codeowner_team: '@googleapis/api-bigquery'
+      codeowner_team: '@googleapis/bigquery-team'
       api_id: bigquerystorage.googleapis.com
       transport: grpc
       requires_billing: true


### PR DESCRIPTION
This PR replaces @googleapis/api-bigquery with @googleapis/bigquery-team and @googleapis/yoshi-java with @googleapis/cloud-sdk-java-team. b/478003109